### PR TITLE
docs: exclude CHANGELOG.md from linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     'esnext',
     '.github/workflows',
     '.husky',
+    'CHANGELOG.md',
   ],
 
   plugins: ['prettier'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,152 +10,152 @@
 
 ### Bug Fixes
 
-- lint issues auto-fix with ESLint ([11b9a07](https://github.com/react-hookz/web/commit/11b9a07fe6f23a305a0581d0e05bf93f55ca53a2))
-- replace husky v6 with husky v4 as v5+ ruins CI lint autofix ([a50955a](https://github.com/react-hookz/web/commit/a50955a44d9fe0d7a90cc481f7d0f2855f708d9a))
+* lint issues auto-fix with ESLint ([11b9a07](https://github.com/react-hookz/web/commit/11b9a07fe6f23a305a0581d0e05bf93f55ca53a2))
+* replace husky v6 with husky v4 as v5+ ruins CI lint autofix ([a50955a](https://github.com/react-hookz/web/commit/a50955a44d9fe0d7a90cc481f7d0f2855f708d9a))
 
 ## [1.7.1](https://github.com/react-hookz/web/compare/v1.7.0...v1.7.1) (2021-04-23)
 
 ### Bug Fixes
 
-- add ci yarn caching layer ([5aa8ae1](https://github.com/react-hookz/web/commit/5aa8ae199e72a88d17809cf5cc5023c7344ed025))
+* add ci yarn caching layer ([5aa8ae1](https://github.com/react-hookz/web/commit/5aa8ae199e72a88d17809cf5cc5023c7344ed025))
 
 # [1.7.0](https://github.com/react-hookz/web/compare/v1.6.2...v1.7.0) (2021-04-23)
 
 ### Bug Fixes
 
-- add `md` and `mdx` files to lint-staged hook glob ([d1d3d72](https://github.com/react-hookz/web/commit/d1d3d7200313c023f874e74720f9d787a9321d78))
-- add readme clarification about different lang level usages ([0632992](https://github.com/react-hookz/web/commit/0632992a39f18e99ca4bd9929d6bdcdb236e9182))
-- exclude new distributed directories from eslint and tsconfig ([058960e](https://github.com/react-hookz/web/commit/058960e9eb60893ce94504a3aac68d4ec1e131a4))
+* add `md` and `mdx` files to lint-staged hook glob ([d1d3d72](https://github.com/react-hookz/web/commit/d1d3d7200313c023f874e74720f9d787a9321d78))
+* add readme clarification about different lang level usages ([0632992](https://github.com/react-hookz/web/commit/0632992a39f18e99ca4bd9929d6bdcdb236e9182))
+* exclude new distributed directories from eslint and tsconfig ([058960e](https://github.com/react-hookz/web/commit/058960e9eb60893ce94504a3aac68d4ec1e131a4))
 
 ### Features
 
-- package now has /cjs, /esm, /esnext distibuted versions ([4911c9d](https://github.com/react-hookz/web/commit/4911c9d3c0813bff5e52ae98cfc4dfc542996a0b))
+* package now has /cjs, /esm, /esnext distibuted versions ([4911c9d](https://github.com/react-hookz/web/commit/4911c9d3c0813bff5e52ae98cfc4dfc542996a0b))
 
 # [1.7.0](https://github.com/react-hookz/web/compare/v1.6.2...v1.7.0) (2021-04-23)
 
 ### Features
 
-- package now has /cjs, /esm, /esnext distibuted versions ([4911c9d](https://github.com/react-hookz/web/commit/4911c9d3c0813bff5e52ae98cfc4dfc542996a0b))
+* package now has /cjs, /esm, /esnext distibuted versions ([4911c9d](https://github.com/react-hookz/web/commit/4911c9d3c0813bff5e52ae98cfc4dfc542996a0b))
 
 ## [1.6.2](https://github.com/react-hookz/web/compare/v1.6.1...v1.6.2) (2021-04-22)
 
 ### Bug Fixes
 
-- add hook link to README.md ([368f1d9](https://github.com/react-hookz/web/commit/368f1d9b595eec113cadffa217ef01041a6a4c72))
+* add hook link to README.md ([368f1d9](https://github.com/react-hookz/web/commit/368f1d9b595eec113cadffa217ef01041a6a4c72))
 
 # [1.7.0](https://github.com/react-hookz/web/compare/v1.6.1...v1.7.0) (2021-04-22)
 
 ### Features
 
-- add storybook docs with deploy to gh-pages ([84de312](https://github.com/react-hookz/web/commit/84de312a607f202c8957ae3f6d32c453cffe134a))
+* add storybook docs with deploy to gh-pages ([84de312](https://github.com/react-hookz/web/commit/84de312a607f202c8957ae3f6d32c453cffe134a))
 
 ## [1.6.1](https://github.com/react-hookz/web/compare/v1.6.0...v1.6.1) (2021-04-21)
 
 ### Bug Fixes
 
-- useUnmountEffect and useMountEffect typings fix ([32ec0c7](https://github.com/react-hookz/web/commit/32ec0c7f7b63c8d8941b95f5f8e5c369e5e87f1a))
+* useUnmountEffect and useMountEffect typings fix ([32ec0c7](https://github.com/react-hookz/web/commit/32ec0c7f7b63c8d8941b95f5f8e5c369e5e87f1a))
 
 # [1.6.0](https://github.com/react-hookz/web/compare/v1.5.0...v1.6.0) (2021-04-21)
 
 ### Features
 
-- useToggle hook ([#3](https://github.com/react-hookz/web/issues/3)) ([3a51779](https://github.com/react-hookz/web/commit/3a51779e21c83c51994a3da59aaf88d729ecc43f))
+* useToggle hook ([#3](https://github.com/react-hookz/web/issues/3)) ([3a51779](https://github.com/react-hookz/web/commit/3a51779e21c83c51994a3da59aaf88d729ecc43f))
 
 # [1.5.0](https://github.com/react-hookz/web/compare/v1.4.3...v1.5.0) (2021-04-21)
 
 ### Features
 
-- make tests import hooks from the index ([3210650](https://github.com/react-hookz/web/commit/3210650220f6e685d91bb7921c725596199eec84))
+* make tests import hooks from the index ([3210650](https://github.com/react-hookz/web/commit/3210650220f6e685d91bb7921c725596199eec84))
 
 ## [1.4.3](https://github.com/react-hookz/web/compare/v1.4.2...v1.4.3) (2021-04-21)
 
 ### Bug Fixes
 
-- dist package returned to bundle ([e92bd18](https://github.com/react-hookz/web/commit/e92bd18a2feafe9ae1770b992d723d31027c72d9))
+* dist package returned to bundle ([e92bd18](https://github.com/react-hookz/web/commit/e92bd18a2feafe9ae1770b992d723d31027c72d9))
 
 ## [1.4.2](https://github.com/react-hookz/web/compare/v1.4.1...v1.4.2) (2021-04-18)
 
 ### Bug Fixes
 
-- add @semantic-release/github plugin ([9f7e1b3](https://github.com/react-hookz/web/commit/9f7e1b3a441674c03ab29af3682f9619fc668806))
+* add @semantic-release/github plugin ([9f7e1b3](https://github.com/react-hookz/web/commit/9f7e1b3a441674c03ab29af3682f9619fc668806))
 
 ## [1.4.1](https://github.com/react-hookz/web/compare/v1.4.0...v1.4.1) (2021-04-16)
 
 ### Bug Fixes
 
-- add types field to package json and tweak build ([8d64b9a](https://github.com/react-hookz/web/commit/8d64b9a1e240df938f177f565c0427b9bedfe934))
+* add types field to package json and tweak build ([8d64b9a](https://github.com/react-hookz/web/commit/8d64b9a1e240df938f177f565c0427b9bedfe934))
 
 # [1.4.0](https://github.com/react-hookz/web/compare/v1.3.0...v1.4.0) (2021-04-16)
 
 ### Features
 
-- add main file and reexport new hooks ([e2ea1cb](https://github.com/react-hookz/web/commit/e2ea1cbf6b5de909945fadde15eafd5ab70cea9f))
+* add main file and reexport new hooks ([e2ea1cb](https://github.com/react-hookz/web/commit/e2ea1cbf6b5de909945fadde15eafd5ab70cea9f))
 
 # [1.3.0](https://github.com/react-hookz/web/compare/v1.2.3...v1.3.0) (2021-04-16)
 
 ### Features
 
-- useUpdateEffect hook ([bc3a655](https://github.com/react-hookz/web/commit/bc3a655f5cbfe3b4edb94c6084f62e95806ea6de))
+* useUpdateEffect hook ([bc3a655](https://github.com/react-hookz/web/commit/bc3a655f5cbfe3b4edb94c6084f62e95806ea6de))
 
 ## [1.2.3](https://github.com/react-hookz/web/compare/v1.2.2...v1.2.3) (2021-04-16)
 
 ### Bug Fixes
 
-- properly name useMountEffect and useUnmountEffect parameter ([5218bfc](https://github.com/react-hookz/web/commit/5218bfcc359b34fe61a46a635c41fb093182a56e))
+* properly name useMountEffect and useUnmountEffect parameter ([5218bfc](https://github.com/react-hookz/web/commit/5218bfcc359b34fe61a46a635c41fb093182a56e))
 
 ## [1.2.2](https://github.com/react-hookz/web/compare/v1.2.1...v1.2.2) (2021-04-15)
 
 ### Bug Fixes
 
-- attempt to make codecov push only occur on release publish ([ac5c221](https://github.com/react-hookz/web/commit/ac5c221659ce8173268c88d9da385411a07009f3))
+* attempt to make codecov push only occur on release publish ([ac5c221](https://github.com/react-hookz/web/commit/ac5c221659ce8173268c88d9da385411a07009f3))
 
 ## [1.2.1](https://github.com/react-hookz/web/compare/v1.2.0...v1.2.1) (2021-04-15)
 
 ### Bug Fixes
 
-- codecov push should only occur on release publish ([2a9e024](https://github.com/react-hookz/web/commit/2a9e0249d83bd7df2b126ad62e5b3aee3ca8dfbc))
+* codecov push should only occur on release publish ([2a9e024](https://github.com/react-hookz/web/commit/2a9e0249d83bd7df2b126ad62e5b3aee3ca8dfbc))
 
 # [1.2.0](https://github.com/react-hookz/web/compare/v1.1.0...v1.2.0) (2021-04-15)
 
 ### Features
 
-- add codecov coverage reporting ([3254871](https://github.com/react-hookz/web/commit/325487121b3fb8a27ab129e31a0cec3bcf7cce1f))
+* add codecov coverage reporting ([3254871](https://github.com/react-hookz/web/commit/325487121b3fb8a27ab129e31a0cec3bcf7cce1f))
 
 # [1.1.0](https://github.com/react-hookz/web/compare/v1.0.0...v1.1.0) (2021-04-15)
 
 ### Features
 
-- implement useMountEffect and useUnmountEffect hooks ([98ec434](https://github.com/react-hookz/web/commit/98ec434d3b9b9e56ebb92ce4bf047a2ef9d19c8f))
+* implement useMountEffect and useUnmountEffect hooks ([98ec434](https://github.com/react-hookz/web/commit/98ec434d3b9b9e56ebb92ce4bf047a2ef9d19c8f))
 
 # 1.0.0 (2021-04-14)
 
 ### Features
 
-- add .npmignore and filler .gitignore files. ([e12375f](https://github.com/react-hookz/web/commit/e12375f2d489938e85dd7abb0fac4dae6d5be7fa))
-- add CI workflow and dependabot config. ([7e365cf](https://github.com/react-hookz/web/commit/7e365cfe16fe1f7ce6c4a5792f7f490890dc14b5))
-- add semantic release dep. ([4e39fa3](https://github.com/react-hookz/web/commit/4e39fa3ee5de0d7a1712601985567320a44b04c6))
-- configure basic builds. ([34aafe4](https://github.com/react-hookz/web/commit/34aafe4d67ea2c27b2a321df8fed15b7e2d50bab))
-- improve ci config and set initial version to 0.0.1 ([adf4dca](https://github.com/react-hookz/web/commit/adf4dca9cbd4e76ffed71fddc05d4875cb67365c))
-- introduce useFirstMountState ([bd7123b](https://github.com/react-hookz/web/commit/bd7123b08dd1dd4d25ce8ae1765bfde19368a7fe))
+* add .npmignore and filler .gitignore files. ([e12375f](https://github.com/react-hookz/web/commit/e12375f2d489938e85dd7abb0fac4dae6d5be7fa))
+* add CI workflow and dependabot config. ([7e365cf](https://github.com/react-hookz/web/commit/7e365cfe16fe1f7ce6c4a5792f7f490890dc14b5))
+* add semantic release dep. ([4e39fa3](https://github.com/react-hookz/web/commit/4e39fa3ee5de0d7a1712601985567320a44b04c6))
+* configure basic builds. ([34aafe4](https://github.com/react-hookz/web/commit/34aafe4d67ea2c27b2a321df8fed15b7e2d50bab))
+* improve ci config and set initial version to 0.0.1 ([adf4dca](https://github.com/react-hookz/web/commit/adf4dca9cbd4e76ffed71fddc05d4875cb67365c))
+* introduce useFirstMountState ([bd7123b](https://github.com/react-hookz/web/commit/bd7123b08dd1dd4d25ce8ae1765bfde19368a7fe))
 
 # 1.0.0 (2021-04-14)
 
 ### Features
 
-- add .npmignore and filler .gitignore files. ([e12375f](https://github.com/react-hookz/web/commit/e12375f2d489938e85dd7abb0fac4dae6d5be7fa))
-- add CI workflow and dependabot config. ([7e365cf](https://github.com/react-hookz/web/commit/7e365cfe16fe1f7ce6c4a5792f7f490890dc14b5))
-- add semantic release dep. ([4e39fa3](https://github.com/react-hookz/web/commit/4e39fa3ee5de0d7a1712601985567320a44b04c6))
-- configure basic builds. ([34aafe4](https://github.com/react-hookz/web/commit/34aafe4d67ea2c27b2a321df8fed15b7e2d50bab))
-- improve ci config and set initial version to 0.0.1 ([adf4dca](https://github.com/react-hookz/web/commit/adf4dca9cbd4e76ffed71fddc05d4875cb67365c))
-- introduce useFirstMountState ([bd7123b](https://github.com/react-hookz/web/commit/bd7123b08dd1dd4d25ce8ae1765bfde19368a7fe))
+* add .npmignore and filler .gitignore files. ([e12375f](https://github.com/react-hookz/web/commit/e12375f2d489938e85dd7abb0fac4dae6d5be7fa))
+* add CI workflow and dependabot config. ([7e365cf](https://github.com/react-hookz/web/commit/7e365cfe16fe1f7ce6c4a5792f7f490890dc14b5))
+* add semantic release dep. ([4e39fa3](https://github.com/react-hookz/web/commit/4e39fa3ee5de0d7a1712601985567320a44b04c6))
+* configure basic builds. ([34aafe4](https://github.com/react-hookz/web/commit/34aafe4d67ea2c27b2a321df8fed15b7e2d50bab))
+* improve ci config and set initial version to 0.0.1 ([adf4dca](https://github.com/react-hookz/web/commit/adf4dca9cbd4e76ffed71fddc05d4875cb67365c))
+* introduce useFirstMountState ([bd7123b](https://github.com/react-hookz/web/commit/bd7123b08dd1dd4d25ce8ae1765bfde19368a7fe))
 
 # 1.0.0 (2021-04-12)
 
 ### Features
 
-- add .npmignore and filler .gitignore files. ([e12375f](https://github.com/react-hookz/web/commit/e12375f2d489938e85dd7abb0fac4dae6d5be7fa))
-- add CI workflow and dependabot config. ([7e365cf](https://github.com/react-hookz/web/commit/7e365cfe16fe1f7ce6c4a5792f7f490890dc14b5))
-- add semantic release dep. ([4e39fa3](https://github.com/react-hookz/web/commit/4e39fa3ee5de0d7a1712601985567320a44b04c6))
-- configure basic builds. ([34aafe4](https://github.com/react-hookz/web/commit/34aafe4d67ea2c27b2a321df8fed15b7e2d50bab))
-- improve ci config and set initial version to 0.0.1 ([adf4dca](https://github.com/react-hookz/web/commit/adf4dca9cbd4e76ffed71fddc05d4875cb67365c))
-- introduce useFirstMountState ([bd7123b](https://github.com/react-hookz/web/commit/bd7123b08dd1dd4d25ce8ae1765bfde19368a7fe))
+* add .npmignore and filler .gitignore files. ([e12375f](https://github.com/react-hookz/web/commit/e12375f2d489938e85dd7abb0fac4dae6d5be7fa))
+* add CI workflow and dependabot config. ([7e365cf](https://github.com/react-hookz/web/commit/7e365cfe16fe1f7ce6c4a5792f7f490890dc14b5))
+* add semantic release dep. ([4e39fa3](https://github.com/react-hookz/web/commit/4e39fa3ee5de0d7a1712601985567320a44b04c6))
+* configure basic builds. ([34aafe4](https://github.com/react-hookz/web/commit/34aafe4d67ea2c27b2a321df8fed15b7e2d50bab))
+* improve ci config and set initial version to 0.0.1 ([adf4dca](https://github.com/react-hookz/web/commit/adf4dca9cbd4e76ffed71fddc05d4875cb67365c))
+* introduce useFirstMountState ([bd7123b](https://github.com/react-hookz/web/commit/bd7123b08dd1dd4d25ce8ae1765bfde19368a7fe))


### PR DESCRIPTION
## What is the problem?

The `CHANGELOG.md` kept getting linted

## What changes does this PR make to fix the problem?

Added it as an exception

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
