### PR TITLE
feat: new hooks, useConditionalEffect and useConditionalUpdateEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ import { useMountEffect } from "@react-hookz/web/esnext";
   - [`useUpdateEffect`](https://react-hookz.github.io/web/?path=/docs/lifecycle-useupdateeffect)
     — Effect hook that ignores the first render (not invoked on mount).
   - [`useConditionalEffect`](https://react-hookz.github.io/web/?path=/docs/lifecycle-useconditionaleffect)
-    — Alike `useEffect` but callback invoked only if conditions match predicate.
+    — Like `useEffect` but callback invoked only if conditions match predicate.
   - [`useConditionalUpdateEffect`](https://react-hookz.github.io/web/?path=/docs/lifecycle-useconditionalupdateeffect)
-    — Alike `useUpdateEffect` but callback invoked only if conditions match predicate.
+    — Like `useUpdateEffect` but callback invoked only if conditions match predicate.
 - #### State
   - [`useToggle`](https://react-hookz.github.io/web/?path=/docs/lifecycle-usetoggle)
     — Like `useState`, but can only become `true` or `false`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ import { useMountEffect } from "@react-hookz/web/esnext";
     — Run effect only when component is unmounted.
   - [`useUpdateEffect`](https://react-hookz.github.io/web/?path=/docs/lifecycle-useupdateeffect)
     — Effect hook that ignores the first render (not invoked on mount).
+  - [`useConditionalEffect`](https://react-hookz.github.io/web/?path=/docs/lifecycle-useconditionaleffect)
+    — Alike `useEffect` but callback invoked only if conditions match predicate.
+  - [`useConditionalUpdateEffect`](https://react-hookz.github.io/web/?path=/docs/lifecycle-useconditionalupdateeffect)
+    — Alike `useUpdateEffect` but callback invoked only if conditions match predicate.
 - #### State
   - [`useToggle`](https://react-hookz.github.io/web/?path=/docs/lifecycle-usetoggle)
     — Like `useState`, but can only become `true` or `false`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export { useToggle } from './useToggle';
 export { useRerender } from './useRerender';
 export { usePrevious } from './usePrevious';
 export { useIsMounted } from './useIsMounted';
+export { useConditionalEffect } from './useConditionalEffect';
+export { useConditionalUpdateEffect } from './useConditionalUpdateEffect';

--- a/src/useConditionalEffect.ts
+++ b/src/useConditionalEffect.ts
@@ -1,0 +1,36 @@
+import { EffectCallback, useEffect, useRef } from 'react';
+import { noop, truthyArrayItemsPredicate } from './util/const';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type IUseConditionalEffectPredicate<Cond extends ReadonlyArray<any>> = (
+  conditions: Cond
+) => boolean;
+
+/**
+ * Alike `useEffect` but callback invoked only if conditions match predicate.
+ *
+ * @param callback Callback to invoke
+ * @param conditions Conditions array
+ * @param predicate Predicate that defines whether conditions satisfying certain
+ * provision. By default, it is all-truthy provision, meaning that all
+ * conditions should be truthy.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useConditionalEffect<T extends ReadonlyArray<any>>(
+  callback: EffectCallback,
+  conditions: T,
+  predicate: IUseConditionalEffectPredicate<T> = truthyArrayItemsPredicate
+): void {
+  const shouldInvoke = predicate(conditions);
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const deps = useRef<{}>();
+
+  // we want callback invocation only in case all conditions matches predicate
+  if (shouldInvoke) {
+    deps.current = {};
+  }
+
+  // we cant avoid on-mount invocations so slip noop callback for the cases we dont need invocation
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(shouldInvoke ? callback : noop, [deps.current]);
+}

--- a/src/useConditionalEffect.ts
+++ b/src/useConditionalEffect.ts
@@ -7,7 +7,7 @@ export type IUseConditionalEffectPredicate<Cond extends ReadonlyArray<any>> = (
 ) => boolean;
 
 /**
- * Alike `useEffect` but callback invoked only if conditions match predicate.
+ * Like `useEffect` but callback invoked only if conditions match predicate.
  *
  * @param callback Callback to invoke
  * @param conditions Conditions array
@@ -30,7 +30,7 @@ export function useConditionalEffect<T extends ReadonlyArray<any>>(
     deps.current = {};
   }
 
-  // we cant avoid on-mount invocations so slip noop callback for the cases we dont need invocation
+  // we can't avoid on-mount invocations so slip noop callback for the cases we dont need invocation
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(shouldInvoke ? callback : noop, [deps.current]);
 }

--- a/src/useConditionalUpdateEffect.ts
+++ b/src/useConditionalUpdateEffect.ts
@@ -1,0 +1,38 @@
+import { EffectCallback, useEffect, useRef } from 'react';
+import { noop, truthyArrayItemsPredicate } from './util/const';
+import { useFirstMountState } from './useFirstMountState';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type IUseConditionalUpdateEffectPredicate<Cond extends ReadonlyArray<any>> = (
+  conditions: Cond
+) => boolean;
+
+/**
+ * Alike `useUpdateEffect` but callback invoked only if conditions match predicate.
+ *
+ * @param callback Callback to invoke
+ * @param conditions Conditions array
+ * @param predicate Predicate that defines whether conditions satisfying certain
+ * provision. By default, it is all-truthy provision, meaning that all
+ * conditions should be truthy.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useConditionalUpdateEffect<T extends ReadonlyArray<any>>(
+  callback: EffectCallback,
+  conditions: T,
+  predicate: IUseConditionalUpdateEffectPredicate<T> = truthyArrayItemsPredicate
+): void {
+  const isFirstMount = useFirstMountState();
+  const shouldInvoke = !isFirstMount && predicate(conditions);
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const deps = useRef<{}>();
+
+  // we want callback invocation only in case all conditions matches predicate
+  if (shouldInvoke) {
+    deps.current = {};
+  }
+
+  // we cant avoid on-mount invocations so slip noop callback for the cases we dont need invocation
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(shouldInvoke ? callback : noop, [deps.current]);
+}

--- a/src/useConditionalUpdateEffect.ts
+++ b/src/useConditionalUpdateEffect.ts
@@ -8,7 +8,7 @@ export type IUseConditionalUpdateEffectPredicate<Cond extends ReadonlyArray<any>
 ) => boolean;
 
 /**
- * Alike `useUpdateEffect` but callback invoked only if conditions match predicate.
+ * Like `useUpdateEffect` but callback invoked only if conditions match predicate.
  *
  * @param callback Callback to invoke
  * @param conditions Conditions array
@@ -32,7 +32,7 @@ export function useConditionalUpdateEffect<T extends ReadonlyArray<any>>(
     deps.current = {};
   }
 
-  // we cant avoid on-mount invocations so slip noop callback for the cases we dont need invocation
+  // we can't avoid on-mount invocations so slip noop callback for the cases we dont need invocation
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(shouldInvoke ? callback : noop, [deps.current]);
 }

--- a/src/useUpdateEffect.ts
+++ b/src/useUpdateEffect.ts
@@ -1,5 +1,6 @@
 import { DependencyList, EffectCallback, useEffect } from 'react';
 import { useFirstMountState } from './useFirstMountState';
+import { noop } from './util/const';
 
 /**
  * Effect hook that ignores the first render (not invoked on mount).
@@ -10,11 +11,6 @@ import { useFirstMountState } from './useFirstMountState';
 export function useUpdateEffect(effect: EffectCallback, deps?: DependencyList): void {
   const isFirstMount = useFirstMountState();
 
-  // eslint-disable-next-line consistent-return
-  useEffect(() => {
-    if (!isFirstMount) {
-      return effect();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(isFirstMount ? noop : effect, deps);
 }

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -4,3 +4,8 @@ export const isBrowser =
   typeof window !== 'undefined' &&
   typeof navigator !== 'undefined' &&
   typeof document !== 'undefined';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function truthyArrayItemsPredicate(conditions: ReadonlyArray<any>): boolean {
+  return conditions.every((i) => Boolean(i));
+}

--- a/stories/useConditionalEffect.stories.tsx
+++ b/stories/useConditionalEffect.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useConditionalEffect } from '../src';
+
+export const Example: React.FC = () => {
+  const [state1, setState1] = useState(2);
+  const [state2, setState2] = useState(2);
+
+  useConditionalEffect(
+    () => {
+      // eslint-disable-next-line no-alert
+      alert('COUNTERS VALUES ARE EVEN');
+    },
+    [state1, state2],
+    (conditions) => conditions.every((i) => i && i % 2 === 0)
+  );
+
+  return (
+    <div>
+      <div>Alert will be displayed when both counters values are even</div>
+      <div>Effect also invoked on initial mount</div>
+      <button
+        onClick={() => {
+          setState1((i) => i + 1);
+        }}>
+        increment counter 1 [{state1}]
+      </button>{' '}
+      <button
+        onClick={() => {
+          setState2((i) => i + 1);
+        }}>
+        increment counter 2 [{state2}]
+      </button>
+    </div>
+  );
+};

--- a/stories/useConditionalEffect.stories.tsx
+++ b/stories/useConditionalEffect.stories.tsx
@@ -1,36 +1,51 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { useConditionalEffect } from '../src';
+import { useConditionalEffect, useToggle } from '../src';
 
 export const Example: React.FC = () => {
-  const [state1, setState1] = useState(2);
-  const [state2, setState2] = useState(2);
+  const [isToggled, toggle] = useToggle(false);
 
-  useConditionalEffect(
-    () => {
-      // eslint-disable-next-line no-alert
-      alert('COUNTERS VALUES ARE EVEN');
-    },
-    [state1, state2],
-    (conditions) => conditions.every((i) => i && i % 2 === 0)
-  );
+  const ToggledComponent: React.FC = () => {
+    const [state1, setState1] = useState(2);
+    const [state2, setState2] = useState(2);
+
+    useConditionalEffect(
+      () => {
+        // eslint-disable-next-line no-alert
+        alert('COUNTERS VALUES ARE EVEN');
+      },
+      [state1, state2],
+      (conditions) => conditions.every((i) => i && i % 2 === 0)
+    );
+
+    return (
+      <div>
+        <div>Alert will be displayed when both counters values are even</div>
+        <div>Effect also invoked on initial mount</div>
+        <button
+          onClick={() => {
+            setState1((i) => i + 1);
+          }}>
+          increment counter 1 [{state1}]
+        </button>{' '}
+        <button
+          onClick={() => {
+            setState2((i) => i + 1);
+          }}>
+          increment counter 2 [{state2}]
+        </button>
+      </div>
+    );
+  };
+
+  if (isToggled) {
+    return <ToggledComponent />;
+  }
 
   return (
     <div>
-      <div>Alert will be displayed when both counters values are even</div>
-      <div>Effect also invoked on initial mount</div>
-      <button
-        onClick={() => {
-          setState1((i) => i + 1);
-        }}>
-        increment counter 1 [{state1}]
-      </button>{' '}
-      <button
-        onClick={() => {
-          setState2((i) => i + 1);
-        }}>
-        increment counter 2 [{state2}]
-      </button>
+      <div>As example component displays alert right from mount - it is initially unmounted.</div>
+      <button onClick={() => toggle()}>Mount example component</button>
     </div>
   );
 };

--- a/stories/useConditionalEffect.story.mdx
+++ b/stories/useConditionalEffect.story.mdx
@@ -5,10 +5,10 @@ import { Example } from "./useConditionalEffect.stories";
 
 # useConditionalEffect
 
-Alike `useEffect` but callback invoked only if conditions match predicate. By default, predicate
+Like `useEffect` but callback invoked only if conditions match predicate. By default, predicate
 matches if all conditions are truthy.
 
-As `useEffect`, it performs conditions match on first mount.
+Like `useEffect`, it performs conditions match on first mount.
 
 #### Example
 
@@ -33,6 +33,6 @@ function useConditionalEffect<T extends ReadonlyArray<any>>(
 #### Arguments
 
 - _**callback**_ _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
-- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that matched against predicate
+- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that are matched against predicate
 - _**predicate**_ _`IUseConditionalEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches conditions.
   By default, it is all-truthy provision, meaning that all conditions should be truthy.

--- a/stories/useConditionalEffect.story.mdx
+++ b/stories/useConditionalEffect.story.mdx
@@ -1,0 +1,38 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
+import { Example } from "./useConditionalEffect.stories";
+
+<Meta title="Lifecycle/useConditionalEffect" component={Example} />
+
+# useConditionalEffect
+
+Alike `useEffect` but callback invoked only if conditions match predicate. By default, predicate
+matches if all conditions are truthy.
+
+As `useEffect`, it performs conditions match on first mount.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+type IUseConditionalEffectPredicate<Cond extends ReadonlyArray<any>> = (
+  conditions: Cond
+) => boolean;
+
+function useConditionalEffect<T extends ReadonlyArray<any>>(
+  callback: React.EffectCallback,
+  conditions: T,
+  predicate?: IUseConditionalEffectPredicate<T>
+): void;
+```
+
+#### Arguments
+
+- _**callback**_ _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
+- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that matched against predicate
+- _**predicate**_ _`IUseConditionalEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches conditions.
+  By default, it is all-truthy provision, meaning that all conditions should be truthy.

--- a/stories/useConditionalUpdateEffect.stories.tsx
+++ b/stories/useConditionalUpdateEffect.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useConditionalUpdateEffect } from '../src';
+
+export const Example: React.FC = () => {
+  const [state1, setState1] = useState(2);
+  const [state2, setState2] = useState(2);
+
+  useConditionalUpdateEffect(
+    () => {
+      // eslint-disable-next-line no-alert
+      alert('COUNTERS VALUES ARE EVEN');
+    },
+    [state1, state2],
+    (conditions) => conditions.every((i) => i && i % 2 === 0)
+  );
+
+  return (
+    <div>
+      <div>Alert will be displayed when both counters values are even</div>
+      <div>But effect not invoked on initial mount</div>
+      <button
+        onClick={() => {
+          setState1((i) => i + 1);
+        }}>
+        increment counter 1 [{state1}]
+      </button>{' '}
+      <button
+        onClick={() => {
+          setState2((i) => i + 1);
+        }}>
+        increment counter 2 [{state2}]
+      </button>
+    </div>
+  );
+};

--- a/stories/useConditionalUpdateEffect.story.mdx
+++ b/stories/useConditionalUpdateEffect.story.mdx
@@ -1,0 +1,38 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
+import { Example } from "./useConditionalUpdateEffect.stories";
+
+<Meta title="Lifecycle/useConditionalUpdateEffect" component={Example} />
+
+# useConditionalUpdateEffect
+
+Alike `useUpdateEffect` but callback invoked only if conditions match predicate. By default, predicate
+matches if all conditions are truthy.
+
+As `useUpdateEffect`, it _does not_ perform conditions match on first mount.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+type IUseConditionalUpdateEffectPredicate<Cond extends ReadonlyArray<any>> = (
+  conditions: Cond
+) => boolean;
+
+function useConditionalUpdateEffect<T extends ReadonlyArray<any>>(
+  callback: React.EffectCallback,
+  conditions: T,
+  predicate?: IUseConditionalUpdateEffectPredicate<T>
+): void;
+```
+
+#### Arguments
+
+- _**callback**_ _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
+- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that matched against predicate
+- _**predicate**_ _`IUseConditionalUpdateEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches conditions.
+  By default, it is all-truthy provision, meaning that all conditions should be truthy.

--- a/stories/useConditionalUpdateEffect.story.mdx
+++ b/stories/useConditionalUpdateEffect.story.mdx
@@ -5,10 +5,10 @@ import { Example } from "./useConditionalUpdateEffect.stories";
 
 # useConditionalUpdateEffect
 
-Alike `useUpdateEffect` but callback invoked only if conditions match predicate. By default, predicate
+Like `useUpdateEffect` but callback invoked only if conditions match predicate. By default, predicate
 matches if all conditions are truthy.
 
-As `useUpdateEffect`, it _does not_ perform conditions match on first mount.
+Like `useUpdateEffect`, it _does not_ perform conditions match on first mount.
 
 #### Example
 
@@ -33,6 +33,6 @@ function useConditionalUpdateEffect<T extends ReadonlyArray<any>>(
 #### Arguments
 
 - _**callback**_ _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
-- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that matched against predicate
+- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that are matched against predicate
 - _**predicate**_ _`IUseConditionalUpdateEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches conditions.
   By default, it is all-truthy provision, meaning that all conditions should be truthy.

--- a/stories/useIsMounted.stories.tsx
+++ b/stories/useIsMounted.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useIsMounted, useMountEffect, useToggle } from '../src';
 
 export const Example: React.FC = () => {
-  const [isToggled, toggle] = useToggle(true);
+  const [isToggled, toggle] = useToggle(false);
 
   const ToggledComponent: React.FC = () => {
     const isMounted = useIsMounted();
@@ -29,6 +29,11 @@ export const Example: React.FC = () => {
 
   return (
     <div>
+      {!isToggled && (
+        <div>
+          As example component displays alert without interaction - it is initially unmounted.
+        </div>
+      )}
       <button
         onClick={() => {
           toggle();

--- a/stories/useUnmountEffect.stories.tsx
+++ b/stories/useUnmountEffect.stories.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { useUnmountEffect, useToggle } from '../src';
-
-const ToggledComponent: React.FC = () => {
-  // eslint-disable-next-line no-alert
-  useUnmountEffect(() => alert('UNMOUNTED'));
-
-  return <p>Unmount me</p>;
-};
+import { useToggle, useUnmountEffect } from '../src';
 
 export const Example: React.FC = () => {
   const [isToggled, toggle] = useToggle(false);
+
+  const ToggledComponent: React.FC = () => {
+    // eslint-disable-next-line no-alert
+    useUnmountEffect(() => alert('UNMOUNTED'));
+
+    return <p>Unmount me</p>;
+  };
 
   return (
     <div>

--- a/tests/dom/useConditionalEffect.test.ts
+++ b/tests/dom/useConditionalEffect.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useConditionalEffect } from '../../src';
+
+describe('useConditionalEffect', () => {
+  it('should be defined', () => {
+    expect(useConditionalEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    renderHook(() => useConditionalEffect(() => {}, []));
+  });
+
+  it('by default should invoke effect only in case all conditions are truthy', () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(({ cond }) => useConditionalEffect(spy, cond), {
+      initialProps: { cond: [1] as unknown[] },
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    rerender({ cond: [0, 1, 1] });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    rerender({ cond: [1, {}, null] });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    rerender({ cond: [true, {}, [], 25] });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not be called on mount if conditions are falsy', () => {
+    const spy = jest.fn();
+    renderHook(({ cond }) => useConditionalEffect(spy, cond), {
+      initialProps: { cond: [null] as unknown[] },
+    });
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should apply custom predicate', () => {
+    const spy = jest.fn();
+    const predicateSpy = jest.fn((arr: unknown[]) => arr.some((i) => Boolean(i)));
+    const { rerender } = renderHook(({ cond }) => useConditionalEffect(spy, cond, predicateSpy), {
+      initialProps: { cond: [null] as unknown[] },
+    });
+    expect(predicateSpy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender({ cond: [true, {}, [], 25] });
+    expect(predicateSpy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    rerender({ cond: [true, false, 0, null] });
+    expect(predicateSpy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    rerender({ cond: [undefined, false, 0, null] });
+    expect(predicateSpy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/dom/useConditionalUpdateEffect.test.ts
+++ b/tests/dom/useConditionalUpdateEffect.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useConditionalUpdateEffect } from '../../src';
+
+describe('useConditionalUpdateEffect', () => {
+  it('should be defined', () => {
+    expect(useConditionalUpdateEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    renderHook(() => useConditionalUpdateEffect(() => {}, []));
+  });
+
+  it('by default should invoke effect only in case all conditions are truthy', () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(({ cond }) => useConditionalUpdateEffect(spy, cond), {
+      initialProps: { cond: [1] as unknown[] },
+    });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender({ cond: [0, 1, 1] });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender({ cond: [1, {}, null] });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender({ cond: [true, {}, [], 25] });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('nor callback neither predicate should not be called on mount', () => {
+    const spy = jest.fn();
+    const predicateSpy = jest.fn(() => true);
+    renderHook(() => useConditionalUpdateEffect(spy, [true], predicateSpy));
+    expect(predicateSpy).toHaveBeenCalledTimes(0);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should apply custom predicate', () => {
+    const spy = jest.fn();
+    const predicateSpy = jest.fn((arr: unknown[]) => arr.some((i) => Boolean(i)));
+    const { rerender } = renderHook(
+      ({ cond }) => useConditionalUpdateEffect(spy, cond, predicateSpy),
+      {
+        initialProps: { cond: [null] as unknown[] },
+      }
+    );
+    expect(predicateSpy).toHaveBeenCalledTimes(0);
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender({ cond: [true, {}, [], 25] });
+    expect(predicateSpy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    rerender({ cond: [true, false, 0, null] });
+    expect(predicateSpy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    rerender({ cond: [undefined, false, 0, null] });
+    expect(predicateSpy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/ssr/useConditionalEffect.test.ts
+++ b/tests/ssr/useConditionalEffect.test.ts
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useConditionalEffect } from '../../src';
+
+describe('useConditionalEffect', () => {
+  it('should be defined', () => {
+    expect(useConditionalEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    renderHook(() => useConditionalEffect(() => {}, []));
+  });
+
+  it('should not invoke effect, but should invoke predicate', () => {
+    const spy = jest.fn();
+    const predicateSpy = jest.fn((arr: unknown[]) => arr.some((i) => Boolean(i)));
+    renderHook(() => useConditionalEffect(spy, [true], predicateSpy));
+    expect(predicateSpy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/tests/ssr/useConditionalUpdateEffect.test.ts
+++ b/tests/ssr/useConditionalUpdateEffect.test.ts
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useConditionalUpdateEffect } from '../../src';
+
+describe('useConditionalUpdateEffect', () => {
+  it('should be defined', () => {
+    expect(useConditionalUpdateEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    renderHook(() => useConditionalUpdateEffect(() => {}, []));
+  });
+
+  it('nor callback neither predicate should not be called on mount', () => {
+    const spy = jest.fn();
+    const predicateSpy = jest.fn(() => true);
+    renderHook(() => useConditionalUpdateEffect(spy, [true], predicateSpy));
+    expect(predicateSpy).toHaveBeenCalledTimes(0);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## What new hook does?

- `useConditionalEffect`  - Alike `useEffect` but callback invoked only if conditions match predicate.
- `useConditionalUpdateEffect` — Alike useUpdateEffect but callback invoked only if conditions match predicate.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
