### PR TITLE
fix: default useUnmountEffect example to false

### DIFF
--- a/stories/useUnmountEffect.stories.tsx
+++ b/stories/useUnmountEffect.stories.tsx
@@ -9,7 +9,7 @@ const ToggledComponent: React.FC = () => {
 };
 
 export const Example: React.FC = () => {
-  const [isToggled, toggle] = useToggle(true);
+  const [isToggled, toggle] = useToggle(false);
 
   return (
     <div>


### PR DESCRIPTION
## What is the problem?

The useMountEffect example triggers a dialogue when you leave the page by default, which is super annoying.

## What changes does this PR make to fix the problem?

The useMountEffect example now requires user interaction before triggering a dialogue.

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
