### PR TITLE
feat: new hook `useSyncedRef`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,8 @@ import { useMountEffect } from "@react-hookz/web/esnext";
 
     - [`useNetworkState`](http://react-hookz.github.io/?path=/docs/sensor-usenetwork--example)
       — Tracks the state of browser's network connection.
+
+- #### Miscellaneous
+
+    - [`useSyncedRef`](http://react-hookz.github.io/?path=/docs/miscellaneous-usesyncedref--example)
+      — Like `useRef`, but it returns immutable ref that contains actual value.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export { useSafeState } from './useSafeState';
 export { useMediatedState } from './useMediatedState';
 export { useDebounceCallback } from './useDebounceCallback';
 export { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+export { useSyncedRef } from './useSyncedRef';

--- a/src/useSyncedRef.ts
+++ b/src/useSyncedRef.ts
@@ -1,0 +1,22 @@
+import { useMemo, useRef } from 'react';
+
+/**
+ * Like `useRef`, but it returns immutable ref that contains actual value.
+ *
+ * @param value
+ */
+export function useSyncedRef<T>(value: T): { readonly current: T } {
+  const _ref = useRef(value);
+
+  _ref.current = value;
+
+  return useMemo(
+    () =>
+      Object.freeze({
+        get current() {
+          return _ref.current;
+        },
+      }),
+    []
+  );
+}

--- a/stories/Miscellaneous/useSyncedRef.stories.tsx
+++ b/stories/Miscellaneous/useSyncedRef.stories.tsx
@@ -1,0 +1,16 @@
+import React, { useRef } from 'react';
+import { useRerender, useSyncedRef } from '../../src';
+
+export const Example: React.FC = () => {
+  const ref = useRef(0);
+  const syncedRef = useSyncedRef(++ref.current);
+  const rerender = useRerender();
+
+  return (
+    <div>
+      <div>As you may see in source code, ref value updated automatically</div>
+      <button onClick={rerender}>Rerender outer component</button>{' '}
+      <span>renders: {syncedRef.current}</span>
+    </div>
+  );
+};

--- a/stories/Miscellaneous/useSyncedRef.story.mdx
+++ b/stories/Miscellaneous/useSyncedRef.story.mdx
@@ -1,0 +1,27 @@
+import {Canvas, Meta, Story} from '@storybook/addon-docs/blocks';
+import {Example} from './useSyncedRef.stories';
+
+<Meta title="Miscellaneous/useSyncedRef" component={Example} />
+
+# useSyncedRef
+
+Like `useRef`, but it returns immutable ref that contains actual value.
+
+> `useSyncedRef` returns frozen object, therefore any attempt to modify returned ref will end up
+exception throw.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+function useSyncedRef<T>(value: T): { readonly current: T };
+```
+
+#### Arguments
+
+- **value** _`any`_ - actual ref value.

--- a/stories/Miscellaneous/useSyncedRef.story.mdx
+++ b/stories/Miscellaneous/useSyncedRef.story.mdx
@@ -10,6 +10,16 @@ Like `useRef`, but it returns immutable ref that contains actual value.
 > `useSyncedRef` returns frozen object, therefore any attempt to modify returned ref will end up
 exception throw.
 
+>This hook initially designed to simplify creation of stable APIs, which, alternatively, would 
+require to write a lot of code like below:
+>```ts
+// before
+const someRef1 = React.useRef<()=>void>();
+someRef1.current = ()=>{};
+// after
+const someRef = useSyncedRef(()=>{});
+>```
+
 #### Example
 
 <Canvas>

--- a/tests/dom/useSyncedRef.test.ts
+++ b/tests/dom/useSyncedRef.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useSyncedRef } from '../../src';
+
+describe('useSyncedRef', () => {
+  it('should be defined', () => {
+    expect(useSyncedRef).toBeDefined();
+  });
+
+  it('should render', () => {
+    renderHook(() => useSyncedRef(1));
+  });
+
+  it('should return ref object', () => {
+    const { result } = renderHook(() => useSyncedRef(1));
+
+    expect(result.current).toEqual({ current: 1 });
+  });
+
+  it('should return same ref between renders', () => {
+    const { result, rerender } = renderHook(() => useSyncedRef(1));
+
+    const ref = result.current;
+    rerender();
+    expect(result.current).toEqual(ref);
+    rerender();
+    expect(result.current).toEqual(ref);
+    rerender();
+    expect(result.current).toEqual(ref);
+  });
+
+  it('should contain actual value on each render', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { result, rerender } = renderHook(({ val }) => useSyncedRef<any>(val), {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialProps: { val: 1 as any },
+    });
+
+    expect(result.current.current).toBe(1);
+    const value1 = { foo: 'bar' };
+    rerender({ val: value1 });
+    expect(result.current.current).toBe(value1);
+    const value2 = ['a', 'b', 'c'];
+    rerender({ val: value2 });
+    expect(result.current.current).toBe(value2);
+  });
+
+  it('should throw on attempt to change ref', () => {
+    const { result } = renderHook(() => useSyncedRef(1));
+
+    expect(() => {
+      // @ts-expect-error testing irrelevant usage
+      result.current.foo = 'bar';
+    }).toThrow(new TypeError('Cannot add property foo, object is not extensible'));
+
+    expect(() => {
+      // @ts-expect-error testing irrelevant usage
+      result.current.current = 2;
+    }).toThrow(new TypeError('Cannot set property current of #<Object> which has only a getter'));
+  });
+});

--- a/tests/ssr/useSyncedRef.test.ts
+++ b/tests/ssr/useSyncedRef.test.ts
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useSyncedRef } from '../../src';
+
+describe('useSyncedRef', () => {
+  it('should be defined', () => {
+    expect(useSyncedRef).toBeDefined();
+  });
+
+  it('should render', () => {
+    renderHook(() => useSyncedRef(1));
+  });
+
+  it('should return ref object', () => {
+    const { result } = renderHook(() => useSyncedRef(1));
+
+    expect(result.current).toEqual({ current: 1 });
+  });
+});


### PR DESCRIPTION
## What new hook does?

Like `useRef`, but it returns immutable ref that contains actual value.

I'm not sure about hook naming, i dont really like the `useSyncedRef`, but it is the best i came up with. 

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
