### PR TITLE
fix: improve `useAsync` typings

### DIFF
--- a/src/useAsync/useAsync.ts
+++ b/src/useAsync/useAsync.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useSafeState, useFirstMountState, useSyncedRef } from '..';
+import { PartialRequired } from '../util/misc';
 
 export type IAsyncStatus = 'loading' | 'success' | 'error' | 'not-executed';
 
@@ -7,7 +8,7 @@ export type IAsyncState<Result> =
   | {
       status: 'not-executed';
       error: undefined;
-      result: Result | undefined;
+      result: Result;
     }
   | {
       status: 'success';
@@ -17,12 +18,12 @@ export type IAsyncState<Result> =
   | {
       status: 'error';
       error: Error;
-      result: Result | undefined;
+      result: Result;
     }
   | {
       status: IAsyncStatus;
       error: Error | undefined;
-      result: Result | undefined;
+      result: Result;
     };
 
 export interface IUseAsyncOptions<Result> {
@@ -63,6 +64,17 @@ export interface IUseAsyncMeta<Result, Args extends unknown[] = unknown[]> {
   lastArgs: Args | undefined;
 }
 
+export function useAsync<Result, Args extends unknown[] = unknown[]>(
+  asyncFn: (...params: Args) => Promise<Result>,
+  args: Args,
+  options: PartialRequired<IUseAsyncOptions<Result>, 'initialValue'>
+): [IAsyncState<Result>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>];
+export function useAsync<Result, Args extends unknown[] = unknown[]>(
+  asyncFn: (...params: Args) => Promise<Result>,
+  args: Args,
+  options?: IUseAsyncOptions<Result>
+): [IAsyncState<Result | undefined>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>];
+
 /**
  * Executes provided async function and tracks its result and error.
  *
@@ -75,8 +87,8 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
   asyncFn: (...params: Args) => Promise<Result>,
   args: Args,
   options?: IUseAsyncOptions<Result>
-): [IAsyncState<Result>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>] {
-  const [state, setState] = useSafeState<IAsyncState<Result>>({
+): [IAsyncState<Result | undefined>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>] {
+  const [state, setState] = useSafeState<IAsyncState<Result | undefined>>({
     status: 'not-executed',
     error: undefined,
     result: options?.initialValue,

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -17,3 +17,6 @@ export function off<T extends EventTarget>(
     obj.removeEventListener(...(args as Parameters<HTMLElement['removeEventListener']>));
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type PartialRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;


### PR DESCRIPTION
`useAsync` return state now properly handles presence of `initialState`
option.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #134
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
