### PR TITLE
Add `deps` argument for `useConditionalUpdateEffect` and `useConditionalEffect` hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,3 +84,5 @@ export { useMediaQuery } from './useMediaQuery/useMediaQuery';
 export { useClickOutside } from './useClickOutside/useClickOutside';
 export { useDocumentTitle, IUseDocumentTitleOptions } from './useDocumentTitle/useDocumentTitle';
 export { useEventListener } from './useEventListener/useEventListener';
+
+export { truthyAndArrayPredicate, truthyOrArrayPredicate } from './util/const';

--- a/src/useConditionalEffect/__docs__/example.stories.tsx
+++ b/src/useConditionalEffect/__docs__/example.stories.tsx
@@ -15,6 +15,7 @@ export const Example: React.FC = () => {
         alert('COUNTERS VALUES ARE EVEN');
       },
       [state1, state2],
+      [state1, state2],
       (conditions) => conditions.every((i) => i && i % 2 === 0)
     );
 

--- a/src/useConditionalEffect/__docs__/story.mdx
+++ b/src/useConditionalEffect/__docs__/story.mdx
@@ -26,13 +26,17 @@ type IUseConditionalEffectPredicate<Cond extends ReadonlyArray<any>> = (
 function useConditionalEffect<T extends ReadonlyArray<any>>(
   callback: React.EffectCallback,
   conditions: T,
+  deps?: React.DependencyList,
   predicate?: IUseConditionalEffectPredicate<T>
 ): void;
 ```
 
 #### Arguments
 
-- _**callback**_ _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
-- _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that are matched against predicate
-- _**predicate**_ _`IUseConditionalEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches conditions.
+- **callback** _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
+- **conditions** _`ReadonlyArray<any>`_ - Conditions that are matched against predicate
+- **deps** _`React.DependencyList`_ - Dependencies list like for `useEffect`. If set - effect will
+  be triggered when deps changed AND conditions are satisfying predicate.
+- **predicate** _`IUseConditionalEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches
+  conditions.
   By default, it is all-truthy provision, meaning that all conditions should be truthy.

--- a/src/useConditionalEffect/__tests__/ssr.ts
+++ b/src/useConditionalEffect/__tests__/ssr.ts
@@ -11,11 +11,11 @@ describe('useConditionalEffect', () => {
     expect(result.error).toBeUndefined();
   });
 
-  it('should not invoke effect, but should invoke predicate', () => {
+  it('should not invoke nor effect nor predicate', () => {
     const spy = jest.fn();
     const predicateSpy = jest.fn((arr: unknown[]) => arr.some((i) => Boolean(i)));
-    renderHook(() => useConditionalEffect(spy, [true], predicateSpy));
-    expect(predicateSpy).toHaveBeenCalledTimes(1);
+    renderHook(() => useConditionalEffect(spy, [true], undefined, predicateSpy));
+    expect(predicateSpy).toHaveBeenCalledTimes(0);
     expect(spy).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/useConditionalEffect/useConditionalEffect.ts
+++ b/src/useConditionalEffect/useConditionalEffect.ts
@@ -1,5 +1,5 @@
-import { EffectCallback, useEffect, useRef } from 'react';
-import { noop, truthyArrayItemsPredicate } from '../util/const';
+import { DependencyList, EffectCallback, useEffect } from 'react';
+import { truthyAndArrayPredicate } from '..';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type IUseConditionalEffectPredicate<Cond extends ReadonlyArray<any>> = (
@@ -11,26 +11,23 @@ export type IUseConditionalEffectPredicate<Cond extends ReadonlyArray<any>> = (
  *
  * @param callback Callback to invoke
  * @param conditions Conditions array
+ * @param deps Dependencies list like for `useEffect`. If set - effect will be
+ * triggered when deps changed AND conditions are satisfying predicate.
  * @param predicate Predicate that defines whether conditions satisfying certain
  * provision. By default, it is all-truthy provision, meaning that all
  * conditions should be truthy.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useConditionalEffect<T extends ReadonlyArray<any>>(
+export function useConditionalEffect<T extends ReadonlyArray<unknown>>(
   callback: EffectCallback,
   conditions: T,
-  predicate: IUseConditionalEffectPredicate<T> = truthyArrayItemsPredicate
+  deps?: DependencyList,
+  predicate: IUseConditionalEffectPredicate<T> = truthyAndArrayPredicate
 ): void {
-  const shouldInvoke = predicate(conditions);
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  const deps = useRef<{}>();
-
-  // we want callback invocation only in case all conditions matches predicate
-  if (shouldInvoke) {
-    deps.current = {};
-  }
-
-  // we can't avoid on-mount invocations so slip noop callback for the cases we dont need invocation
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(shouldInvoke ? callback : noop, [deps.current]);
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (predicate(conditions)) {
+      return callback();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
 }

--- a/src/useConditionalUpdateEffect/__docs__/example.stories.tsx
+++ b/src/useConditionalUpdateEffect/__docs__/example.stories.tsx
@@ -12,6 +12,7 @@ export const Example: React.FC = () => {
       alert('COUNTERS VALUES ARE EVEN');
     },
     [state1, state2],
+    [state1, state2],
     (conditions) => conditions.every((i) => i && i % 2 === 0)
   );
 

--- a/src/useConditionalUpdateEffect/__docs__/story.mdx
+++ b/src/useConditionalUpdateEffect/__docs__/story.mdx
@@ -26,6 +26,7 @@ type IUseConditionalUpdateEffectPredicate<Cond extends ReadonlyArray<any>> = (
 function useConditionalUpdateEffect<T extends ReadonlyArray<any>>(
   callback: React.EffectCallback,
   conditions: T,
+  deps?: React.DependencyList,
   predicate?: IUseConditionalUpdateEffectPredicate<T>
 ): void;
 ```
@@ -34,5 +35,8 @@ function useConditionalUpdateEffect<T extends ReadonlyArray<any>>(
 
 - _**callback**_ _`React.EffectCallback`_ - Effect callback like for `React.useEffect` hook
 - _**conditions**_ _`ReadonlyArray<any>`_ - Conditions that are matched against predicate
-- _**predicate**_ _`IUseConditionalUpdateEffectPredicate<ReadonlyArray<any>>`_ - Predicate that matches conditions.
+- **deps** _`React.DependencyList`_ - Dependencies list like for `useEffect`. If set - effect will
+  be triggered when deps changed AND conditions are satisfying predicate.
+- _**predicate**_ _`IUseConditionalUpdateEffectPredicate<ReadonlyArray<any>>`_ - Predicate that
+  matches conditions.
   By default, it is all-truthy provision, meaning that all conditions should be truthy.

--- a/src/useConditionalUpdateEffect/__tests__/ssr.ts
+++ b/src/useConditionalUpdateEffect/__tests__/ssr.ts
@@ -14,7 +14,7 @@ describe('useConditionalUpdateEffect', () => {
   it('nor callback neither predicate should not be called on mount', () => {
     const spy = jest.fn();
     const predicateSpy = jest.fn(() => true);
-    renderHook(() => useConditionalUpdateEffect(spy, [true], predicateSpy));
+    renderHook(() => useConditionalUpdateEffect(spy, [true], undefined, predicateSpy));
     expect(predicateSpy).toHaveBeenCalledTimes(0);
     expect(spy).toHaveBeenCalledTimes(0);
   });

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -5,7 +5,10 @@ export const isBrowser =
   typeof navigator !== 'undefined' &&
   typeof document !== 'undefined';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function truthyArrayItemsPredicate(conditions: ReadonlyArray<any>): boolean {
+export function truthyAndArrayPredicate(conditions: ReadonlyArray<unknown>): boolean {
   return conditions.every((i) => Boolean(i));
+}
+
+export function truthyOrArrayPredicate(conditions: ReadonlyArray<unknown>): boolean {
+  return conditions.some((i) => Boolean(i));
 }


### PR DESCRIPTION
## What new hook does?

Add `deps` argument for `useConditionalUpdateEffect` and `useConditionalEffect` hooks

BREAKING CHANGE: `useConditionalUpdateEffect` and `useConditionalEffect` now has changed call signature (new argument).

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  - #157 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
