### PR TITLE
docs: create migration guide for react-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ import { useMountEffect } from "@react-hookz/web/esm";
 import { useMountEffect } from "@react-hookz/web/esnext";
 ```
 
+## Migrating from react-use
+
+Coming from `react-use`? Check out our [migration guide](https://react-hookz.github.io/web/?path=/docs/migrating-from-react-use).
+
 ## Hooks list
 
 - #### Callback

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -444,7 +444,7 @@ Not implemented yet
 
 #### useStateValidator
 
-](https://github.com/streamich/react-use/blob/master/docs/useStateValidator.md) — tracks state of an object.
+// - UseValidator link is missing from the issue and the docs are broken
 
 #### useStateWithHistory
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -78,6 +78,8 @@ Not implemented yet
 
 Implemented as [useMediaQuery](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery)
 
+No API changes, besides name change.
+
 #### useMediaDevices
 
 Not implemented yet
@@ -101,6 +103,8 @@ Not implemented yet
 #### useNetworkState
 
 Implemented as [useNetwork](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork)
+
+No API changes, besides name change.
 
 #### useOrientation
 
@@ -138,9 +142,11 @@ Not implemented yet
 
 Implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure)
 
+No API changes.
+
 #### useSize
 
-Not implemented yet
+Use [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure) instead.
 
 #### createBreakpoint
 
@@ -159,6 +165,8 @@ Not implemented yet
 #### useClickAway
 
 Implmented as [useClickOutside](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside))
+
+No API changes, besides name change.
 
 #### useCss
 
@@ -222,9 +230,11 @@ Not implemented yet
 
 Implemented as [useRerender](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRerender)
 
+No API changes, besides name change.
+
 ### Side-effects
 
-#### useAsync
+#### useAsync and useAsyncFn and useAsyncRetry
 
 Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
 
@@ -242,7 +252,32 @@ Not implemented yet
 
 #### useCookie
 
-Implemented as [useCookie](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookie)
+Implemented as [useCookieValue](https://react-hookz.github.io/web/?path=/docs/side-effect-useCookieValue)
+
+OLD in `react-use`:
+
+```javascript
+const [value, set, remove] = useCookie("my-cookie");
+
+console.log(value);
+set("Hello world!", options);
+remove();
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const [value, set, remove] = useCookieValue("react-hookz", options);
+
+console.log(value);
+set("Hello world!");
+remove();
+```
+
+NOTES:
+
+- `js-cookies` needs installed separately from `@react-hookz/web` to use `useCookie`
+- `useCookie` instances with the same key on same page are synchronised. This synchronisation does not work across tabs or on changes that are triggered by third-party code.
 
 #### useCopyToClipboard
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -343,6 +343,8 @@ No plans to implement
 
 Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted)
 
+No API change, besides name change.
+
 #### useUnmountPromise
 
 Not implemented yet
@@ -359,17 +361,25 @@ Not implemented yet
 
 Implemented as [useMountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useMountEffect)
 
+No API change, besides name change.
+
 #### useUnmount
 
 Implemented as [useUnmountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUnmountEffect)
+
+No API change, besides name change.
 
 #### useUpdateEffect
 
 Implemented as [useUpdateEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUpdateEffect)
 
+No API change.
+
 #### useIsomorphicLayoutEffect
 
 Implemented as [useIsomorphicLayoutEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsomorphicLayoutEffect)
+
+No API changes.
 
 #### useDeepCompareEffect
 
@@ -417,9 +427,13 @@ Not implemented yet
 
 Implemented as [useSynchedRef](https://react-hookz.github.io/web/?path=/docs/miscellaneous-usesyncedref)
 
+No API changes, besides name change.
+
 #### usePrevious
 
 Implemented as [usePrevious](https://react-hookz.github.io/web/?path=/docs/state-useprevious)
+
+No API changes.
 
 #### usePreviousDistinct
 
@@ -445,9 +459,11 @@ Not implemented yet
 
 Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle)
 
+No API changes.
+
 #### useBoolean
 
-Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle)
+Use [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle) instead
 
 #### useCounter
 
@@ -469,6 +485,39 @@ Not implemented yet
 
 Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usemap)
 
+OLD in `react-use`:
+
+```javascript
+const [map, { set, remove, reset, setAll }] = useMap({
+  hello: "there",
+});
+
+console.log(JSON.stringify(map, null, 2));
+set("some", "thing");
+remove("hello");
+reset();
+setAll({ hello: "there", some: "thing" });
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const map = useMap(new Map([['hello', 'there']]););
+
+console.log(JSON.stringify(Array.from(map), null, 2));
+map.set("some", "thing");
+map.delete("hello");
+map.clear();
+// There is no native `setAll` method on `Map`s, but we can create our own easily
+const setAll = (values) => {
+    map.clear();
+    valuePairs.forEach((valuePair) => map.set(valuePair[0], valuePair[1]));
+}
+setAll([['hello', 'there']]);
+```
+
+NOTES: `@react-hookz/web`'s implementation is the same signature as the native `Map` object, but its methods are wrapped to cause components to rerender with changes.
+
 #### useSet
 
 Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset)
@@ -489,7 +538,7 @@ toggle("hello");
 NEW in `@react-hookz/web`:
 
 ```javascript
-const set = useSet(new Set(["hello", "world"]));
+const set = useSet(["hello", "world"]);
 
 console.log(JSON.stringify(Array.from(set), null, 2));
 set.add(String(Date.now()));
@@ -501,7 +550,7 @@ const toggle = (value) => (set.has(value) ? set.delete(value) : set.add(value));
 toggle("hello");
 ```
 
-NOTES: `@react-hookz/web`'s implementation is the same signature as the native `Set` object, but its methods are wrapped to cause componentf to rerender with changes.
+NOTES: `@react-hookz/web`'s implementation is the same signature as the native `Set` object, but its methods are wrapped to cause components to rerender with changes.
 
 #### useQueue
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -4,7 +4,7 @@ One of `@react-hookz/web`'s primary goals is to replace [react-use](https://gith
 
 ## A note on missing hooks
 
-Many of `react-use`'s hooks have already been ported to `@react-hookz/web`. You can track our work in [this issue](https://github.com/react-hookz/web/issues/33).
+The most common `react-use` hooks have already been ported to `@react-hookz/web`. You can track our progress porting the rest of `react-use`'s hooks in [this issue](https://github.com/react-hookz/web/issues/33).
 
 If there is a `react-use` hook you need that isn't ported yet, please comment there - or even better, make a PR!
 
@@ -74,7 +74,9 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useMedia](https://github.com/streamich/react-use/blob/master/docs/useMedia.md) — tracks state of a CSS media query. (implemented as [useMediaQuery](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery))
+#### useMedia
+
+Implemented as [useMediaQuery](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery)
 
 #### useMediaDevices
 
@@ -96,7 +98,9 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useNetworkState](https://github.com/streamich/react-use/blob/master/docs/useNetworkState.md) — tracks the state of browser's network connection. (implemented as [useNetwork](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork))
+#### useNetworkState
+
+Implemented as [useNetwork](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork)
 
 #### useOrientation
 
@@ -130,7 +134,9 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useMeasure](https://github.com/streamich/react-use/blob/master/docs/useMeasure.md) — tracks an HTML element's dimensions. (implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure))
+#### useMeasure
+
+Implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure)
 
 #### useSize
 
@@ -150,7 +156,9 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useClickAway](https://github.com/streamich/react-use/blob/master/docs/useClickAway.md) — triggers callback when user clicks outside target area. (Implmented as [useClickOutside](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside))
+#### useClickAway
+
+Implmented as [useClickOutside](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside))
 
 #### useCss
 
@@ -210,25 +218,41 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useUpdate](https://github.com/streamich/react-use/blob/master/docs/useUpdate.md) — returns a callback, which re-renders component when called. (Implemented as [useRerender](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRerender))
+#### useUpdate
+
+Implemented as [useRerender](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRerender)
 
 ### Side-effects
 
-- [x] [useAsync](https://github.com/streamich/react-use/blob/master/docs/useAsync.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
-- [x] [useAsyncFn](https://github.com/streamich/react-use/blob/master/docs/useAsyncFn.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
-- [x] [useAsyncRetry](https://github.com/streamich/react-use/blob/master/docs/useAsyncRetry.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
+#### useAsync
+
+Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+
+#### useAsyncFn
+
+Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+
+#### useAsyncRetry
+
+Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
 
 #### useBeforeUnload
 
 Not implemented yet
 
-- [x] [useCookie](https://github.com/streamich/react-use/blob/master/docs/useCookie.md) — provides way to read, update and delete a cookie. (implemented as [useCookie](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookie))
+#### useCookie
+
+Implemented as [useCookie](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookie)
 
 #### useCopyToClipboard
 
 Not implemented yet
 
-- [x] [useDebounce](https://github.com/streamich/react-use/blob/master/docs/useDebounce.md) — debounces a function. (Implemented as [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback))
+#### useDebounce
+
+`@react-hookz/web` has three options for debouncing, which we feel are both more ergonomic and flexible than `react-use`'s implementation.
+
+Implemented as [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback)
 
 #### useError
 
@@ -238,7 +262,9 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useLocalStorage](https://github.com/streamich/react-use/blob/master/docs/useLocalStorage.md) — manages a value in localStorage. (Implemented as [useLocalStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue))
+#### useLocalStorage
+
+Implemented as [useLocalStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue)
 
 #### useLockBodyScroll
 
@@ -248,15 +274,21 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useSessionStorage](https://github.com/streamich/react-use/blob/master/docs/useSessionStorage.md) — manages a value in sessionStorage. (Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue))
-- [x] [useThrottle](https://github.com/streamich/react-use/blob/master/docs/useThrottle.md) — throttles a function.
+#### useSessionStorage
 
-#### useThrottleFn
+Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue)
 
-No plans to implement
+#### useThrottle and useThrottleFn
 
-- [x] [useTitle](https://github.com/streamich/react-use/blob/master/docs/useTitle.md) — sets title of the page. (Implemented as [useDocumentTitle](https://react-hookz.github.io/web/?path=/docs/dom-usedocumenttitle))
-- [x] [usePermission](https://github.com/streamich/react-use/blob/master/docs/usePermission.md) — query permission status for browser APIs. (Implemented as [usePermission](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission))
+`@react-hookz/web` has three options for throttling, which we feel are both more ergonomic and flexible than `react-use`'s implementations.
+
+#### useTitle
+
+Implemented as [useDocumentTitle](https://react-hookz.github.io/web/?path=/docs/dom-usedocumenttitle)
+
+#### usePermission
+
+Implemented as [usePermission](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission)
 
 ### Lifecycles
 
@@ -264,13 +296,17 @@ No plans to implement
 
 No plans to implement
 
-- [x] [useEvent](https://github.com/streamich/react-use/blob/master/docs/useEvent.md) — subscribe to events. (Implemented as [useEventListener](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener))
+#### useEvent
+
+Implemented as [useEventListener](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener)
 
 #### useLifecycles
 
 No plans to implement
 
-- [x] [useMountedState](https://github.com/streamich/react-use/blob/master/docs/useMountedState.md) — track if component is mounted. (Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted))
+#### useMountedState
+
+Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted)
 
 #### useUnmountPromise
 
@@ -284,10 +320,21 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useMount](https://github.com/streamich/react-use/blob/master/docs/useMount.md) — calls mount callbacks. (Implemented as [useMountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useMountEffect))
-- [x] [useUnmount](https://github.com/streamich/react-use/blob/master/docs/useUnmount.md) — calls unmount callbacks. (Implemented as [useUnmountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUnmountEffect))
-- [x] [useUpdateEffect](https://github.com/streamich/react-use/blob/master/docs/useUpdateEffect.md) — run an effect only on updates. (Implemented as [useUpdateEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUpdateEffect))
-- [x] [useIsomorphicLayoutEffect](https://github.com/streamich/react-use/blob/master/docs/useIsomorphicLayoutEffect.md) — useLayoutEffect that does not show warning when server-side rendering. (Implemented as [useIsomorphicLayoutEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsomorphicLayoutEffect))
+#### useMount
+
+Implemented as [useMountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useMountEffect)
+
+#### useUnmount
+
+Implemented as [useUnmountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUnmountEffect)
+
+#### useUpdateEffect
+
+Implemented as [useUpdateEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUpdateEffect)
+
+#### useIsomorphicLayoutEffect
+
+Implemented as [useIsomorphicLayoutEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsomorphicLayoutEffect)
 
 #### useDeepCompareEffect
 
@@ -331,8 +378,13 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useLatest](https://github.com/streamich/react-use/blob/master/docs/useLatest.md) — returns the latest state or props (as useSynchedRef)
-- [x] [usePrevious](https://github.com/streamich/react-use/blob/master/docs/usePrevious.md) — returns the previous state or props. (Implemented as [usePrevious](https://react-hookz.github.io/web/?path=/docs/state-useprevious))
+#### useLatest
+
+Implemented as [useSynchedRef](https://react-hookz.github.io/web/?path=/docs/miscellaneous-usesyncedref)
+
+#### usePrevious
+
+Implemented as [usePrevious](https://react-hookz.github.io/web/?path=/docs/state-useprevious)
 
 #### usePreviousDistinct
 
@@ -354,8 +406,13 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useToggle](https://github.com/streamich/react-use/blob/master/docs/useToggle.md) — tracks state of a boolean. (Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle))
-- [x] [useBoolean](https://github.com/streamich/react-use/blob/master/docs/useBoolean.md) — tracks state of a boolean. (Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle))
+#### useToggle
+
+Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle)
+
+#### useBoolean
+
+Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle)
 
 #### useCounter
 
@@ -373,14 +430,21 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useMap](https://github.com/streamich/react-use/blob/master/docs/useMap.md) — tracks state of an object. (Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usemap))
-- [x] [useSet](https://github.com/streamich/react-use/blob/master/docs/useSet.md) — tracks state of a Set. (Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset))
+#### useMap
+
+Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usemap)
+
+#### useSet
+
+Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset)
 
 #### useQueue
 
 Not implemented yet
 
-- [x] [useStateValidator](https://github.com/streamich/react-use/blob/master/docs/useStateValidator.md) — tracks state of an object.
+#### useStateValidator
+
+](https://github.com/streamich/react-use/blob/master/docs/useStateValidator.md) — tracks state of an object.
 
 #### useStateWithHistory
 
@@ -390,8 +454,13 @@ Not implemented yet
 
 Not implemented yet
 
-- [x] [useMediatedState](https://github.com/streamich/react-use/blob/master/docs/useMediatedState.md) — like the regular useState but with mediation by custom function. (Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate))
-- [x] [useFirstMountState](https://github.com/streamich/react-use/blob/master/docs/useFirstMountState.md) — check if current render is first. (Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate))
+#### useMediatedState
+
+Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate)
+
+#### useFirstMountState
+
+Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate)
 
 #### useRendersCount
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -277,7 +277,7 @@ remove();
 NOTES:
 
 - `js-cookies` needs installed separately from `@react-hookz/web` to use `useCookie`
-- `useCookie` instances with the same key on same page are synchronised. This synchronisation does not work across tabs or on changes that are triggered by third-party code.
+- `useCookie` instances with the same key on the same page are synchronised. This synchronisation does not work across tabs or on changes that are triggered by third-party code.
 
 #### useCopyToClipboard
 
@@ -473,6 +473,36 @@ Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usem
 
 Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset)
 
+OLD in `react-use`:
+
+```javascript
+const [set, { add, reset, remove, has, toggle }] = useSet(new Set(["hello", "world"]));
+
+console.log(JSON.stringify(Array.from(set), null, 2));
+add(String(Date.now()));
+reset();
+remove("hello");
+has("hello");
+toggle("hello");
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const set = useSet(new Set(["hello", "world"]));
+
+console.log(JSON.stringify(Array.from(set), null, 2));
+set.add(String(Date.now()));
+set.clear();
+set.delete("hello");
+set.has("hello");
+// There is no native `toggle` method on `Set`s, but we can create our own easily
+const toggle = (value) => (set.has(value) ? set.delete(value) : set.add(value));
+toggle("hello");
+```
+
+NOTES: `@react-hookz/web`'s implementation is the same signature as the native `Set` object, but its methods are wrapped to cause componentf to rerender with changes.
+
 #### useQueue
 
 Not implemented yet
@@ -493,9 +523,29 @@ Not implemented yet
 
 Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate)
 
+OLD in `react-use`:
+
+```javascript
+const [state, setState] = useMediatedState((value) => value, "");
+
+console.log(state);
+setState("Hello world!");
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const [state, setState] = useMediatedState("", (value) => value);
+
+console.log(state);
+setState("Hello world!");
+```
+
 #### useFirstMountState
 
 Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate)
+
+No API changes.
 
 #### useRendersCount
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -18,65 +18,198 @@ See [our README](https://github.com/react-hookz/web).
 
 ### Sensors
 
-- [ ] [useBattery](https://github.com/streamich/react-use/blob/master/docs/useBattery.md) — tracks device battery state.
-- [ ] [useGeolocation](https://github.com/streamich/react-use/blob/master/docs/useGeolocation.md) — tracks geo location state of user's device.
-- [ ] [useHover](https://github.com/streamich/react-use/blob/master/docs/useHover.md) — tracks mouse hover state of some element.
-- [ ] [useHoverDirty](https://github.com/streamich/react-use/blob/master/docs/useHoverDirty.md) — tracks mouse hover state of some element.
-- [ ] [useHash](https://github.com/streamich/react-use/blob/master/docs/useHash.md) — tracks location hash value.
-- [ ] [useIdle](https://github.com/streamich/react-use/blob/master/docs/useIdle.md) — tracks whether user is being inactive.
-- [ ] [useIntersection](https://github.com/streamich/react-use/blob/master/docs/useIntersection.md) — tracks an HTML element's intersection. (Implemented as [useIntersectionObserver](https://react-hookz.github.io/web/?path=/docs/sensor-useintersectionobserver))
-- [ ] [useKey](https://github.com/streamich/react-use/blob/master/docs/useKey.md) — track keys.
-- [ ] [useKeyPress](https://github.com/streamich/react-use/blob/master/docs/useKeyPress.md) — track keys.
-- [ ] [useKeyboardJs](https://github.com/streamich/react-use/blob/master/docs/useKeyboardJs.md) — track keys.
-- [ ] [useKeyPressEvent](https://github.com/streamich/react-use/blob/master/docs/useKeyPressEvent.md) — track keys.
-- [ ] [useLocation](https://github.com/streamich/react-use/blob/master/docs/useLocation.md) — tracks page navigation bar location state.
-- [ ] [useSearchParam](https://github.com/streamich/react-use/blob/master/docs/useSearchParam.md) — tracks page navigation bar location state.
-- [ ] [useLongPress](https://github.com/streamich/react-use/blob/master/docs/useLongPress.md) — tracks long press gesture of some element.
+#### useBattery
+
+Not implemented yet
+
+#### useGeolocation
+
+Not implemented yet
+
+#### useHover
+
+Not implemented yet
+
+#### useHoverDirty
+
+Not implemented yet
+
+#### useHash
+
+Not implemented yet
+
+#### useIdle
+
+Not implemented yet
+
+#### useIntersection
+
+Not implemented yet
+
+#### useKey
+
+Not implemented yet
+
+#### useKeyPress
+
+Not implemented yet
+
+#### useKeyboardJs
+
+Not implemented yet
+
+#### useKeyPressEvent
+
+Not implemented yet
+
+#### useLocation
+
+Not implemented yet
+
+#### useSearchParam
+
+Not implemented yet
+
+#### useLongPress
+
+Not implemented yet
+
 - [x] [useMedia](https://github.com/streamich/react-use/blob/master/docs/useMedia.md) — tracks state of a CSS media query. (implemented as [useMediaQuery](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery))
-- [ ] [useMediaDevices](https://github.com/streamich/react-use/blob/master/docs/useMediaDevices.md) — tracks state of connected hardware devices.
-- [ ] [useMotion](https://github.com/streamich/react-use/blob/master/docs/useMotion.md) — tracks state of device's motion sensor.
-- [ ] [useMouse](https://github.com/streamich/react-use/blob/master/docs/useMouse.md) — tracks state of mouse position.
-- [ ] [useMouseHovered](https://github.com/streamich/react-use/blob/master/docs/useMouseHovered.md) — tracks state of mouse position.
-- [ ] [useMouseWheel](https://github.com/streamich/react-use/blob/master/docs/useMouseWheel.md) — tracks deltaY of scrolled mouse wheel.
+
+#### useMediaDevices
+
+Not implemented yet
+
+#### useMotion
+
+Not implemented yet
+
+#### useMouse
+
+Not implemented yet
+
+#### useMouseHovered
+
+Not implemented yet
+
+#### useMouseWheel
+
+Not implemented yet
+
 - [x] [useNetworkState](https://github.com/streamich/react-use/blob/master/docs/useNetworkState.md) — tracks the state of browser's network connection. (implemented as [useNetwork](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork))
-- [ ] [useOrientation](https://github.com/streamich/react-use/blob/master/docs/useOrientation.md) — tracks state of device's screen orientation.
-- [ ] [usePageLeave](https://github.com/streamich/react-use/blob/master/docs/usePageLeave.md) — triggers when mouse leaves page boundaries.
-- [ ] [useScratch](https://github.com/streamich/react-use/blob/master/docs/useScratch.md) — tracks mouse click-and-scrub state.
-- [ ] [useScroll](https://github.com/streamich/react-use/blob/master/docs/useScroll.md) — tracks an HTML element's scroll position.
-- [ ] [useScrolling](https://github.com/streamich/react-use/blob/master/docs/useScrolling.md) — tracks whether HTML element is scrolling.
-- [ ] [useStartTyping](https://github.com/streamich/react-use/blob/master/docs/useStartTyping.md) — detects when user starts typing.
-- [ ] [useWindowScroll](https://github.com/streamich/react-use/blob/master/docs/useWindowScroll.md) — tracks Window scroll position.
-- [ ] [useWindowSize](https://github.com/streamich/react-use/blob/master/docs/useWindowSize.md) — tracks Window dimensions.
+
+#### useOrientation
+
+Not implemented yet
+
+#### usePageLeave
+
+Not implemented yet
+
+#### useScratch
+
+Not implemented yet
+
+#### useScroll
+
+Not implemented yet
+
+#### useScrolling
+
+Not implemented yet
+
+#### useStartTyping
+
+Not implemented yet
+
+#### useWindowScroll
+
+Not implemented yet
+
+#### useWindowSize
+
+Not implemented yet
+
 - [x] [useMeasure](https://github.com/streamich/react-use/blob/master/docs/useMeasure.md) — tracks an HTML element's dimensions. (implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure))
-- [ ] [useSize](https://github.com/streamich/react-use/blob/master/docs/useSize.md) — tracks an HTML element's dimensions.
+
+#### useSize
+
+Not implemented yet
 
 #### createBreakpoint
 
 No plans to implement
 
-- [ ] [useScrollbarWidth](https://github.com/streamich/react-use/blob/master/docs/useScrollbarWidth.md) — detects browser's native scrollbars width.
+#### useScrollbarWidth
+
+Not implemented yet
 
 ### UI
 
-- [ ] [useAudio](https://github.com/streamich/react-use/blob/master/docs/useAudio.md) — plays audio and exposes its controls.
+#### useAudio
+
+Not implemented yet
+
 - [x] [useClickAway](https://github.com/streamich/react-use/blob/master/docs/useClickAway.md) — triggers callback when user clicks outside target area. (Implmented as [useClickOutside](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside))
-- [ ] [useCss](https://github.com/streamich/react-use/blob/master/docs/useCss.md) — dynamically adjusts CSS.
-- [ ] [useDrop](https://github.com/streamich/react-use/blob/master/docs/useDrop.md) — tracks file, link and copy-paste drops.
-- [ ] [useDropArea](https://github.com/streamich/react-use/blob/master/docs/useDropArea.md) — tracks file, link and copy-paste drops.
-- [ ] [useFullscreen](https://github.com/streamich/react-use/blob/master/docs/useFullscreen.md) — display an element or video full-screen.
-- [ ] [useSlider](https://github.com/streamich/react-use/blob/master/docs/useSlider.md) — provides slide behavior over any HTML element.
-- [ ] [useSpeech](https://github.com/streamich/react-use/blob/master/docs/useSpeech.md) — synthesizes speech from a text string.
-- [ ] [useVibrate](https://github.com/streamich/react-use/blob/master/docs/useVibrate.md) — provide physical feedback using the Vibration API.
-- [ ] [useVideo](https://github.com/streamich/react-use/blob/master/docs/useVideo.md) — plays video, tracks its state, and exposes playback controls.
+
+#### useCss
+
+Not implemented yet
+
+#### useDrop
+
+Not implemented yet
+
+#### useDropArea
+
+Not implemented yet
+
+#### useFullscreen
+
+Not implemented yet
+
+#### useSlider
+
+Not implemented yet
+
+#### useSpeech
+
+Not implemented yet
+
+#### useVibrate
+
+Not implemented yet
+
+#### useVideo
+
+Not implemented yet
 
 ### Animations
 
-- [ ] [useRaf](https://github.com/streamich/react-use/blob/master/docs/useRaf.md) — re-renders component on each requestAnimationFrame.
-- [ ] [useInterval](https://github.com/streamich/react-use/blob/master/docs/useInterval.md) and useHarmonicIntervalFn — re-renders component on a set interval using setInterval.
-- [ ] [useSpring](https://github.com/streamich/react-use/blob/master/docs/useSpring.md) — interpolates number over time according to spring dynamics.
-- [ ] [useTimeout](https://github.com/streamich/react-use/blob/master/docs/useTimeout.md) — re-renders component after a timeout.
-- [ ] [useTimeoutFn](https://github.com/streamich/react-use/blob/master/docs/useTimeoutFn.md) — calls given function after a timeout.
-- [ ] [useTween](https://github.com/streamich/react-use/blob/master/docs/useTween.md) — re-renders component, while tweening a number from 0 to 1.
+#### useRaf
+
+Not implemented yet
+
+#### useInterval
+
+Not implemented yet
+
+#### useSpring
+
+Not implemented yet
+
+#### useTimeout
+
+Not implemented yet
+
+#### useTimeoutFn
+
+Not implemented yet
+
+#### useTween
+
+Not implemented yet
+
 - [x] [useUpdate](https://github.com/streamich/react-use/blob/master/docs/useUpdate.md) — returns a callback, which re-renders component when called. (Implemented as [useRerender](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRerender))
 
 ### Side-effects
@@ -84,15 +217,37 @@ No plans to implement
 - [x] [useAsync](https://github.com/streamich/react-use/blob/master/docs/useAsync.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
 - [x] [useAsyncFn](https://github.com/streamich/react-use/blob/master/docs/useAsyncFn.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
 - [x] [useAsyncRetry](https://github.com/streamich/react-use/blob/master/docs/useAsyncRetry.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
-- [ ] [useBeforeUnload](https://github.com/streamich/react-use/blob/master/docs/useBeforeUnload.md) — shows browser alert when user try to reload or close the page.
+
+#### useBeforeUnload
+
+Not implemented yet
+
 - [x] [useCookie](https://github.com/streamich/react-use/blob/master/docs/useCookie.md) — provides way to read, update and delete a cookie. (implemented as [useCookie](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookie))
-- [ ] [useCopyToClipboard](https://github.com/streamich/react-use/blob/master/docs/useCopyToClipboard.md) — copies text to clipboard.
+
+#### useCopyToClipboard
+
+Not implemented yet
+
 - [x] [useDebounce](https://github.com/streamich/react-use/blob/master/docs/useDebounce.md) — debounces a function. (Implemented as [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback))
-- [ ] [useError](https://github.com/streamich/react-use/blob/master/docs/useError.md) — error dispatcher.
-- [ ] [useFavicon](https://github.com/streamich/react-use/blob/master/docs/useFavicon.md) — sets favicon of the page.
+
+#### useError
+
+Not implemented yet
+
+#### useFavicon
+
+Not implemented yet
+
 - [x] [useLocalStorage](https://github.com/streamich/react-use/blob/master/docs/useLocalStorage.md) — manages a value in localStorage. (Implemented as [useLocalStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue))
-- [ ] [useLockBodyScroll](https://github.com/streamich/react-use/blob/master/docs/useLockBodyScroll.md) — lock scrolling of the body element.
-- [ ] [useRafLoop](https://github.com/streamich/react-use/blob/master/docs/useRafLoop.md) — calls given function inside the RAF loop.
+
+#### useLockBodyScroll
+
+Not implemented yet
+
+#### useRafLoop
+
+Not implemented yet
+
 - [x] [useSessionStorage](https://github.com/streamich/react-use/blob/master/docs/useSessionStorage.md) — manages a value in sessionStorage. (Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue))
 - [x] [useThrottle](https://github.com/streamich/react-use/blob/master/docs/useThrottle.md) — throttles a function.
 
@@ -116,16 +271,35 @@ No plans to implement
 No plans to implement
 
 - [x] [useMountedState](https://github.com/streamich/react-use/blob/master/docs/useMountedState.md) — track if component is mounted. (Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted))
-- [ ] [useUnmountPromise](https://github.com/streamich/react-use/blob/master/docs/useUnmountPromise.md) — track if component is mounted.
-- [ ] [usePromise](https://github.com/streamich/react-use/blob/master/docs/usePromise.md) — resolves promise only while component is mounted.
-- [ ] [useLogger](https://github.com/streamich/react-use/blob/master/docs/useLogger.md) — logs in console as component goes through life-cycles.
+
+#### useUnmountPromise
+
+Not implemented yet
+
+#### usePromise
+
+Not implemented yet
+
+#### useLogger
+
+Not implemented yet
+
 - [x] [useMount](https://github.com/streamich/react-use/blob/master/docs/useMount.md) — calls mount callbacks. (Implemented as [useMountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useMountEffect))
 - [x] [useUnmount](https://github.com/streamich/react-use/blob/master/docs/useUnmount.md) — calls unmount callbacks. (Implemented as [useUnmountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUnmountEffect))
 - [x] [useUpdateEffect](https://github.com/streamich/react-use/blob/master/docs/useUpdateEffect.md) — run an effect only on updates. (Implemented as [useUpdateEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUpdateEffect))
 - [x] [useIsomorphicLayoutEffect](https://github.com/streamich/react-use/blob/master/docs/useIsomorphicLayoutEffect.md) — useLayoutEffect that does not show warning when server-side rendering. (Implemented as [useIsomorphicLayoutEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsomorphicLayoutEffect))
-- [ ] [useDeepCompareEffect](https://github.com/streamich/react-use/blob/master/docs/useDeepCompareEffect.md) — run an effect depending on deep comparison of its dependencies
-- [ ] [useShallowCompareEffect](https://github.com/streamich/react-use/blob/master/docs/useShallowCompareEffect.md) — run an effect depending on deep comparison of its dependencies
-- [ ] [useCustomCompareEffect](https://github.com/streamich/react-use/blob/master/docs/useCustomCompareEffect.md) — run an effect depending on deep comparison of its dependencies
+
+#### useDeepCompareEffect
+
+Not implemented yet
+
+#### useShallowCompareEffect
+
+Not implemented yet
+
+#### useCustomCompareEffect
+
+Not implemented yet
 
 ### State
 
@@ -145,39 +319,98 @@ No plans to implement
 
 No plans to implement
 
-- [ ] [useDefault](https://github.com/streamich/react-use/blob/master/docs/useDefault.md) — returns the default value when state is null or undefined.
-- [ ] [useGetSet](https://github.com/streamich/react-use/blob/master/docs/useGetSet.md) — returns state getter get() instead of raw state.
-- [ ] [useGetSetState](https://github.com/streamich/react-use/blob/master/docs/useGetSetState.md) — as if useGetSet and useSetState had a baby.
+#### useDefault
+
+Not implemented yet
+
+#### useGetSet
+
+Not implemented yet
+
+#### useGetSetState
+
+Not implemented yet
+
 - [x] [useLatest](https://github.com/streamich/react-use/blob/master/docs/useLatest.md) — returns the latest state or props (as useSynchedRef)
 - [x] [usePrevious](https://github.com/streamich/react-use/blob/master/docs/usePrevious.md) — returns the previous state or props. (Implemented as [usePrevious](https://react-hookz.github.io/web/?path=/docs/state-useprevious))
-- [ ] [usePreviousDistinct](https://github.com/streamich/react-use/blob/master/docs/usePreviousDistinct.md) — like usePrevious but with a predicate to determine if previous should update.
-- [ ] [useObservable](https://github.com/streamich/react-use/blob/master/docs/useObservable.md) — tracks latest value of an Observable.
-- [ ] [useRafState](https://github.com/streamich/react-use/blob/master/docs/useRafState.md) — creates setState method which only updates after requestAnimationFrame.
-- [ ] [useSetState](https://github.com/streamich/react-use/blob/master/docs/useSetState.md) — creates setState method which works like this.setState.
-- [ ] [useStateList](https://github.com/streamich/react-use/blob/master/docs/useStateList.md) — circularly iterates over an array.
+
+#### usePreviousDistinct
+
+Not implemented yet
+
+#### useObservable
+
+Not implemented yet
+
+#### useRafState
+
+Not implemented yet
+
+#### useSetState
+
+Not implemented yet
+
+#### useStateList
+
+Not implemented yet
+
 - [x] [useToggle](https://github.com/streamich/react-use/blob/master/docs/useToggle.md) — tracks state of a boolean. (Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle))
 - [x] [useBoolean](https://github.com/streamich/react-use/blob/master/docs/useBoolean.md) — tracks state of a boolean. (Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle))
-- [ ] [useCounter](https://github.com/streamich/react-use/blob/master/docs/useCounter.md) — tracks state of a number.
-- [ ] [useNumber](https://github.com/streamich/react-use/blob/master/docs/useNumber.md) — tracks state of a number.
-- [ ] [useList](https://github.com/streamich/react-use/blob/master/docs/useList.md) — tracks state of an array.
-- [ ] [useUpsert](https://github.com/streamich/react-use/blob/master/docs/useUpsert.md) — tracks state of an array.
+
+#### useCounter
+
+Not implemented yet
+
+#### useNumber
+
+Not implemented yet
+
+#### useList
+
+Not implemented yet
+
+#### useUpsert
+
+Not implemented yet
+
 - [x] [useMap](https://github.com/streamich/react-use/blob/master/docs/useMap.md) — tracks state of an object. (Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usemap))
 - [x] [useSet](https://github.com/streamich/react-use/blob/master/docs/useSet.md) — tracks state of a Set. (Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset))
-- [ ] [useQueue](https://github.com/streamich/react-use/blob/master/docs/useQueue.md) — implements simple queue.
+
+#### useQueue
+
+Not implemented yet
+
 - [x] [useStateValidator](https://github.com/streamich/react-use/blob/master/docs/useStateValidator.md) — tracks state of an object.
-- [ ] [useStateWithHistory](https://github.com/streamich/react-use/blob/master/docs/useStateWithHistory.md) — stores previous state values and provides handles to travel through them.
-- [ ] [useMultiStateValidator](https://github.com/streamich/react-use/blob/master/docs/useMultiStateValidator.md) — alike the useStateValidator, but tracks multiple states at a time.
+
+#### useStateWithHistory
+
+Not implemented yet
+
+#### useMultiStateValidator
+
+Not implemented yet
+
 - [x] [useMediatedState](https://github.com/streamich/react-use/blob/master/docs/useMediatedState.md) — like the regular useState but with mediation by custom function. (Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate))
 - [x] [useFirstMountState](https://github.com/streamich/react-use/blob/master/docs/useFirstMountState.md) — check if current render is first. (Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate))
-- [ ] [useRendersCount](https://github.com/streamich/react-use/blob/master/docs/useRendersCount.md) — count component renders.
+
+#### useRendersCount
+
+Not implemented yet
 
 #### createGlobalState
 
 No plans to implement
 
-- [ ] [useMethods](https://github.com/streamich/react-use/blob/master/docs/useMethods.md) — neat alternative to useReducer.
+#### useMethods
+
+Not implemented yet
 
 ### Miscellaneous
 
-- [ ] [useEnsuredForwardedRef](https://github.com/streamich/react-use/blob/master/docs/useEnsuredForwardedRef.md) — use a React.forwardedRef safely.
-- [ ] [ensuredForwardRef](https://github.com/streamich/react-use/blob/master/docs/ensuredForwardRef.md) — use a React.forwardedRef safely.
+#### useEnsuredForwardedRef
+
+Not implemented yet
+
+#### ensuredForwardRef
+
+Not implemented yet

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -15,3 +15,138 @@ In the mean time, **feel free to use both `@react-hookz/web` and `react-use` in 
 See [our README](https://github.com/react-hookz/web).
 
 ## Migrating Hooks
+
+### Sensors
+
+- [ ] [useBattery](https://github.com/streamich/react-use/blob/master/docs/useBattery.md) — tracks device battery state.
+- [ ] [useGeolocation](https://github.com/streamich/react-use/blob/master/docs/useGeolocation.md) — tracks geo location state of user's device.
+- [ ] [useHover](https://github.com/streamich/react-use/blob/master/docs/useHover.md) — tracks mouse hover state of some element.
+- [ ] [useHoverDirty](https://github.com/streamich/react-use/blob/master/docs/useHoverDirty.md) — tracks mouse hover state of some element.
+- [ ] [useHash](https://github.com/streamich/react-use/blob/master/docs/useHash.md) — tracks location hash value.
+- [ ] [useIdle](https://github.com/streamich/react-use/blob/master/docs/useIdle.md) — tracks whether user is being inactive.
+- [ ] [useIntersection](https://github.com/streamich/react-use/blob/master/docs/useIntersection.md) — tracks an HTML element's intersection. (Implemented as [useIntersectionObserver](https://react-hookz.github.io/web/?path=/docs/sensor-useintersectionobserver))
+- [ ] [useKey](https://github.com/streamich/react-use/blob/master/docs/useKey.md) — track keys.
+- [ ] [useKeyPress](https://github.com/streamich/react-use/blob/master/docs/useKeyPress.md) — track keys.
+- [ ] [useKeyboardJs](https://github.com/streamich/react-use/blob/master/docs/useKeyboardJs.md) — track keys.
+- [ ] [useKeyPressEvent](https://github.com/streamich/react-use/blob/master/docs/useKeyPressEvent.md) — track keys.
+- [ ] [useLocation](https://github.com/streamich/react-use/blob/master/docs/useLocation.md) — tracks page navigation bar location state.
+- [ ] [useSearchParam](https://github.com/streamich/react-use/blob/master/docs/useSearchParam.md) — tracks page navigation bar location state.
+- [ ] [useLongPress](https://github.com/streamich/react-use/blob/master/docs/useLongPress.md) — tracks long press gesture of some element.
+- [x] [useMedia](https://github.com/streamich/react-use/blob/master/docs/useMedia.md) — tracks state of a CSS media query. (implemented as [useMediaQuery](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery))
+- [ ] [useMediaDevices](https://github.com/streamich/react-use/blob/master/docs/useMediaDevices.md) — tracks state of connected hardware devices.
+- [ ] [useMotion](https://github.com/streamich/react-use/blob/master/docs/useMotion.md) — tracks state of device's motion sensor.
+- [ ] [useMouse](https://github.com/streamich/react-use/blob/master/docs/useMouse.md) — tracks state of mouse position.
+- [ ] [useMouseHovered](https://github.com/streamich/react-use/blob/master/docs/useMouseHovered.md) — tracks state of mouse position.
+- [ ] [useMouseWheel](https://github.com/streamich/react-use/blob/master/docs/useMouseWheel.md) — tracks deltaY of scrolled mouse wheel.
+- [x] [useNetworkState](https://github.com/streamich/react-use/blob/master/docs/useNetworkState.md) — tracks the state of browser's network connection. (implemented as [useNetwork](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork))
+- [ ] [useOrientation](https://github.com/streamich/react-use/blob/master/docs/useOrientation.md) — tracks state of device's screen orientation.
+- [ ] [usePageLeave](https://github.com/streamich/react-use/blob/master/docs/usePageLeave.md) — triggers when mouse leaves page boundaries.
+- [ ] [useScratch](https://github.com/streamich/react-use/blob/master/docs/useScratch.md) — tracks mouse click-and-scrub state.
+- [ ] [useScroll](https://github.com/streamich/react-use/blob/master/docs/useScroll.md) — tracks an HTML element's scroll position.
+- [ ] [useScrolling](https://github.com/streamich/react-use/blob/master/docs/useScrolling.md) — tracks whether HTML element is scrolling.
+- [ ] [useStartTyping](https://github.com/streamich/react-use/blob/master/docs/useStartTyping.md) — detects when user starts typing.
+- [ ] [useWindowScroll](https://github.com/streamich/react-use/blob/master/docs/useWindowScroll.md) — tracks Window scroll position.
+- [ ] [useWindowSize](https://github.com/streamich/react-use/blob/master/docs/useWindowSize.md) — tracks Window dimensions.
+- [x] [useMeasure](https://github.com/streamich/react-use/blob/master/docs/useMeasure.md) — tracks an HTML element's dimensions. (implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure))
+- [ ] [useSize](https://github.com/streamich/react-use/blob/master/docs/useSize.md) — tracks an HTML element's dimensions.
+- [ ] ~~[createBreakpoint](https://github.com/streamich/react-use/blob/master/docs/createBreakpoint.md) — tracks innerWidth~~ (Not planning to implement)
+- [ ] [useScrollbarWidth](https://github.com/streamich/react-use/blob/master/docs/useScrollbarWidth.md) — detects browser's native scrollbars width.
+
+### UI
+
+- [ ] [useAudio](https://github.com/streamich/react-use/blob/master/docs/useAudio.md) — plays audio and exposes its controls.
+- [x] [useClickAway](https://github.com/streamich/react-use/blob/master/docs/useClickAway.md) — triggers callback when user clicks outside target area. (Implmented as [useClickOutside](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside))
+- [ ] [useCss](https://github.com/streamich/react-use/blob/master/docs/useCss.md) — dynamically adjusts CSS.
+- [ ] [useDrop](https://github.com/streamich/react-use/blob/master/docs/useDrop.md) — tracks file, link and copy-paste drops.
+- [ ] [useDropArea](https://github.com/streamich/react-use/blob/master/docs/useDropArea.md) — tracks file, link and copy-paste drops.
+- [ ] [useFullscreen](https://github.com/streamich/react-use/blob/master/docs/useFullscreen.md) — display an element or video full-screen.
+- [ ] [useSlider](https://github.com/streamich/react-use/blob/master/docs/useSlider.md) — provides slide behavior over any HTML element.
+- [ ] [useSpeech](https://github.com/streamich/react-use/blob/master/docs/useSpeech.md) — synthesizes speech from a text string.
+- [ ] [useVibrate](https://github.com/streamich/react-use/blob/master/docs/useVibrate.md) — provide physical feedback using the Vibration API.
+- [ ] [useVideo](https://github.com/streamich/react-use/blob/master/docs/useVideo.md) — plays video, tracks its state, and exposes playback controls.
+
+### Animations
+
+- [ ] [useRaf](https://github.com/streamich/react-use/blob/master/docs/useRaf.md) — re-renders component on each requestAnimationFrame.
+- [ ] [useInterval](https://github.com/streamich/react-use/blob/master/docs/useInterval.md) and useHarmonicIntervalFn — re-renders component on a set interval using setInterval.
+- [ ] [useSpring](https://github.com/streamich/react-use/blob/master/docs/useSpring.md) — interpolates number over time according to spring dynamics.
+- [ ] [useTimeout](https://github.com/streamich/react-use/blob/master/docs/useTimeout.md) — re-renders component after a timeout.
+- [ ] [useTimeoutFn](https://github.com/streamich/react-use/blob/master/docs/useTimeoutFn.md) — calls given function after a timeout.
+- [ ] [useTween](https://github.com/streamich/react-use/blob/master/docs/useTween.md) — re-renders component, while tweening a number from 0 to 1.
+- [x] [useUpdate](https://github.com/streamich/react-use/blob/master/docs/useUpdate.md) — returns a callback, which re-renders component when called. (Implemented as [useRerender](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRerender))
+
+### Side-effects
+
+- [x] [useAsync](https://github.com/streamich/react-use/blob/master/docs/useAsync.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
+- [x] [useAsyncFn](https://github.com/streamich/react-use/blob/master/docs/useAsyncFn.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
+- [x] [useAsyncRetry](https://github.com/streamich/react-use/blob/master/docs/useAsyncRetry.md) — resolves an async function. (implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync))
+- [ ] [useBeforeUnload](https://github.com/streamich/react-use/blob/master/docs/useBeforeUnload.md) — shows browser alert when user try to reload or close the page.
+- [x] [useCookie](https://github.com/streamich/react-use/blob/master/docs/useCookie.md) — provides way to read, update and delete a cookie. (implemented as [useCookie](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookie))
+- [ ] [useCopyToClipboard](https://github.com/streamich/react-use/blob/master/docs/useCopyToClipboard.md) — copies text to clipboard.
+- [x] [useDebounce](https://github.com/streamich/react-use/blob/master/docs/useDebounce.md) — debounces a function. (Implemented as [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback))
+- [ ] [useError](https://github.com/streamich/react-use/blob/master/docs/useError.md) — error dispatcher.
+- [ ] [useFavicon](https://github.com/streamich/react-use/blob/master/docs/useFavicon.md) — sets favicon of the page.
+- [x] [useLocalStorage](https://github.com/streamich/react-use/blob/master/docs/useLocalStorage.md) — manages a value in localStorage. (Implemented as [useLocalStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue))
+- [ ] [useLockBodyScroll](https://github.com/streamich/react-use/blob/master/docs/useLockBodyScroll.md) — lock scrolling of the body element.
+- [ ] [useRafLoop](https://github.com/streamich/react-use/blob/master/docs/useRafLoop.md) — calls given function inside the RAF loop.
+- [x] [useSessionStorage](https://github.com/streamich/react-use/blob/master/docs/useSessionStorage.md) — manages a value in sessionStorage. (Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue))
+- [x] [useThrottle](https://github.com/streamich/react-use/blob/master/docs/useThrottle.md) — throttles a function.
+- [ ] ~~[useThrottleFn](https://github.com/streamich/react-use/blob/master/docs/useThrottleFn.md) — throttles a function.~~
+- [x] [useTitle](https://github.com/streamich/react-use/blob/master/docs/useTitle.md) — sets title of the page. (Implemented as [useDocumentTitle](https://react-hookz.github.io/web/?path=/docs/dom-usedocumenttitle))
+- [x] [usePermission](https://github.com/streamich/react-use/blob/master/docs/usePermission.md) — query permission status for browser APIs. (Implemented as [usePermission](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission))
+
+### Lifecycles
+
+- [ ] ~~[useEffectOnce](https://github.com/streamich/react-use/blob/master/docs/useEffectOnce.md) — a modified useEffect hook that only runs once.~~ (it's just an alias for `useMountEffect`)
+- [x] [useEvent](https://github.com/streamich/react-use/blob/master/docs/useEvent.md) — subscribe to events. (Implemented as [useEventListener](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener))
+- [ ] ~~[useLifecycles](https://github.com/streamich/react-use/blob/master/docs/useLifecycles.md) — calls mount and unmount callbacks.~~ (no sense to port, has almost no benefit comparing to `useEffect`)
+- [x] [useMountedState](https://github.com/streamich/react-use/blob/master/docs/useMountedState.md) — track if component is mounted. (Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted))
+- [ ] [useUnmountPromise](https://github.com/streamich/react-use/blob/master/docs/useUnmountPromise.md) — track if component is mounted.
+- [ ] [usePromise](https://github.com/streamich/react-use/blob/master/docs/usePromise.md) — resolves promise only while component is mounted.
+- [ ] [useLogger](https://github.com/streamich/react-use/blob/master/docs/useLogger.md) — logs in console as component goes through life-cycles.
+- [x] [useMount](https://github.com/streamich/react-use/blob/master/docs/useMount.md) — calls mount callbacks. (Implemented as [useMountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useMountEffect))
+- [x] [useUnmount](https://github.com/streamich/react-use/blob/master/docs/useUnmount.md) — calls unmount callbacks. (Implemented as [useUnmountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUnmountEffect))
+- [x] [useUpdateEffect](https://github.com/streamich/react-use/blob/master/docs/useUpdateEffect.md) — run an effect only on updates. (Implemented as [useUpdateEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUpdateEffect))
+- [x] [useIsomorphicLayoutEffect](https://github.com/streamich/react-use/blob/master/docs/useIsomorphicLayoutEffect.md) — useLayoutEffect that does not show warning when server-side rendering. (Implemented as [useIsomorphicLayoutEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsomorphicLayoutEffect))
+- [ ] [useDeepCompareEffect](https://github.com/streamich/react-use/blob/master/docs/useDeepCompareEffect.md) — run an effect depending on deep comparison of its dependencies
+- [ ] [useShallowCompareEffect](https://github.com/streamich/react-use/blob/master/docs/useShallowCompareEffect.md) — run an effect depending on deep comparison of its dependencies
+- [ ] [useCustomCompareEffect](https://github.com/streamich/react-use/blob/master/docs/useCustomCompareEffect.md) — run an effect depending on deep comparison of its dependencies
+
+### State
+
+- [ ] ~~[createMemo](https://github.com/streamich/react-use/blob/master/docs/createMemo.md) — factory of memoized hooks.~~ (Not planning to implement)
+- [ ] ~~[createReducer](https://github.com/streamich/react-use/blob/master/docs/createReducer.md) — factory of reducer hooks with custom middleware.~~ (Not planning to implement)
+- [ ] ~~[createReducerContext](https://github.com/streamich/react-use/blob/master/docs/createReducerContext.md) — factory of hooks for a sharing state between components.~~ (Not planning to implement)
+- [ ] ~~[createStateContext](https://github.com/streamich/react-use/blob/master/docs/createStateContext.md) — factory of hooks for a sharing state between components.~~ (Not planning to implement)
+- [ ] [useDefault](https://github.com/streamich/react-use/blob/master/docs/useDefault.md) — returns the default value when state is null or undefined.
+- [ ] [useGetSet](https://github.com/streamich/react-use/blob/master/docs/useGetSet.md) — returns state getter get() instead of raw state.
+- [ ] [useGetSetState](https://github.com/streamich/react-use/blob/master/docs/useGetSetState.md) — as if useGetSet and useSetState had a baby.
+- [x] [useLatest](https://github.com/streamich/react-use/blob/master/docs/useLatest.md) — returns the latest state or props (as useSynchedRef)
+- [x] [usePrevious](https://github.com/streamich/react-use/blob/master/docs/usePrevious.md) — returns the previous state or props. (Implemented as [usePrevious](https://react-hookz.github.io/web/?path=/docs/state-useprevious))
+- [ ] [usePreviousDistinct](https://github.com/streamich/react-use/blob/master/docs/usePreviousDistinct.md) — like usePrevious but with a predicate to determine if previous should update.
+- [ ] [useObservable](https://github.com/streamich/react-use/blob/master/docs/useObservable.md) — tracks latest value of an Observable.
+- [ ] [useRafState](https://github.com/streamich/react-use/blob/master/docs/useRafState.md) — creates setState method which only updates after requestAnimationFrame.
+- [ ] [useSetState](https://github.com/streamich/react-use/blob/master/docs/useSetState.md) — creates setState method which works like this.setState.
+- [ ] [useStateList](https://github.com/streamich/react-use/blob/master/docs/useStateList.md) — circularly iterates over an array.
+- [x] [useToggle](https://github.com/streamich/react-use/blob/master/docs/useToggle.md) — tracks state of a boolean. (Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle))
+- [x] [useBoolean](https://github.com/streamich/react-use/blob/master/docs/useBoolean.md) — tracks state of a boolean. (Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle))
+- [ ] [useCounter](https://github.com/streamich/react-use/blob/master/docs/useCounter.md) — tracks state of a number.
+- [ ] [useNumber](https://github.com/streamich/react-use/blob/master/docs/useNumber.md) — tracks state of a number.
+- [ ] [useList](https://github.com/streamich/react-use/blob/master/docs/useList.md) — tracks state of an array.
+- [ ] [useUpsert](https://github.com/streamich/react-use/blob/master/docs/useUpsert.md) — tracks state of an array.
+- [x] [useMap](https://github.com/streamich/react-use/blob/master/docs/useMap.md) — tracks state of an object. (Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usemap))
+- [x] [useSet](https://github.com/streamich/react-use/blob/master/docs/useSet.md) — tracks state of a Set. (Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset))
+- [ ] [useQueue](https://github.com/streamich/react-use/blob/master/docs/useQueue.md) — implements simple queue.
+- [x] [useStateValidator](https://github.com/streamich/react-use/blob/master/docs/useStateValidator.md) — tracks state of an object.
+- [ ] [useStateWithHistory](https://github.com/streamich/react-use/blob/master/docs/useStateWithHistory.md) — stores previous state values and provides handles to travel through them.
+- [ ] [useMultiStateValidator](https://github.com/streamich/react-use/blob/master/docs/useMultiStateValidator.md) — alike the useStateValidator, but tracks multiple states at a time.
+- [x] [useMediatedState](https://github.com/streamich/react-use/blob/master/docs/useMediatedState.md) — like the regular useState but with mediation by custom function. (Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate))
+- [x] [useFirstMountState](https://github.com/streamich/react-use/blob/master/docs/useFirstMountState.md) — check if current render is first. (Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate))
+- [ ] [useRendersCount](https://github.com/streamich/react-use/blob/master/docs/useRendersCount.md) — count component renders.
+- [ ] ~~[createGlobalState](https://github.com/streamich/react-use/blob/master/docs/createGlobalState.md) — cross component shared state.~~ (Not planning to implement)
+- [ ] [useMethods](https://github.com/streamich/react-use/blob/master/docs/useMethods.md) — neat alternative to useReducer.
+
+### Miscellaneous
+
+- [ ] [useEnsuredForwardedRef](https://github.com/streamich/react-use/blob/master/docs/useEnsuredForwardedRef.md) — use a React.forwardedRef safely.
+- [ ] [ensuredForwardRef](https://github.com/streamich/react-use/blob/master/docs/ensuredForwardRef.md) — use a React.forwardedRef safely.

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -49,7 +49,11 @@ See [our README](https://github.com/react-hookz/web).
 - [ ] [useWindowSize](https://github.com/streamich/react-use/blob/master/docs/useWindowSize.md) — tracks Window dimensions.
 - [x] [useMeasure](https://github.com/streamich/react-use/blob/master/docs/useMeasure.md) — tracks an HTML element's dimensions. (implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure))
 - [ ] [useSize](https://github.com/streamich/react-use/blob/master/docs/useSize.md) — tracks an HTML element's dimensions.
-- [ ] ~~[createBreakpoint](https://github.com/streamich/react-use/blob/master/docs/createBreakpoint.md) — tracks innerWidth~~ (Not planning to implement)
+
+#### createBreakpoint
+
+No plans to implement
+
 - [ ] [useScrollbarWidth](https://github.com/streamich/react-use/blob/master/docs/useScrollbarWidth.md) — detects browser's native scrollbars width.
 
 ### UI
@@ -91,15 +95,26 @@ See [our README](https://github.com/react-hookz/web).
 - [ ] [useRafLoop](https://github.com/streamich/react-use/blob/master/docs/useRafLoop.md) — calls given function inside the RAF loop.
 - [x] [useSessionStorage](https://github.com/streamich/react-use/blob/master/docs/useSessionStorage.md) — manages a value in sessionStorage. (Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue))
 - [x] [useThrottle](https://github.com/streamich/react-use/blob/master/docs/useThrottle.md) — throttles a function.
-- [ ] ~~[useThrottleFn](https://github.com/streamich/react-use/blob/master/docs/useThrottleFn.md) — throttles a function.~~
+
+#### useThrottleFn
+
+No plans to implement
+
 - [x] [useTitle](https://github.com/streamich/react-use/blob/master/docs/useTitle.md) — sets title of the page. (Implemented as [useDocumentTitle](https://react-hookz.github.io/web/?path=/docs/dom-usedocumenttitle))
 - [x] [usePermission](https://github.com/streamich/react-use/blob/master/docs/usePermission.md) — query permission status for browser APIs. (Implemented as [usePermission](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission))
 
 ### Lifecycles
 
-- [ ] ~~[useEffectOnce](https://github.com/streamich/react-use/blob/master/docs/useEffectOnce.md) — a modified useEffect hook that only runs once.~~ (it's just an alias for `useMountEffect`)
+#### useEffectOnce
+
+No plans to implement
+
 - [x] [useEvent](https://github.com/streamich/react-use/blob/master/docs/useEvent.md) — subscribe to events. (Implemented as [useEventListener](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener))
-- [ ] ~~[useLifecycles](https://github.com/streamich/react-use/blob/master/docs/useLifecycles.md) — calls mount and unmount callbacks.~~ (no sense to port, has almost no benefit comparing to `useEffect`)
+
+#### useLifecycles
+
+No plans to implement
+
 - [x] [useMountedState](https://github.com/streamich/react-use/blob/master/docs/useMountedState.md) — track if component is mounted. (Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted))
 - [ ] [useUnmountPromise](https://github.com/streamich/react-use/blob/master/docs/useUnmountPromise.md) — track if component is mounted.
 - [ ] [usePromise](https://github.com/streamich/react-use/blob/master/docs/usePromise.md) — resolves promise only while component is mounted.
@@ -114,10 +129,22 @@ See [our README](https://github.com/react-hookz/web).
 
 ### State
 
-- [ ] ~~[createMemo](https://github.com/streamich/react-use/blob/master/docs/createMemo.md) — factory of memoized hooks.~~ (Not planning to implement)
-- [ ] ~~[createReducer](https://github.com/streamich/react-use/blob/master/docs/createReducer.md) — factory of reducer hooks with custom middleware.~~ (Not planning to implement)
-- [ ] ~~[createReducerContext](https://github.com/streamich/react-use/blob/master/docs/createReducerContext.md) — factory of hooks for a sharing state between components.~~ (Not planning to implement)
-- [ ] ~~[createStateContext](https://github.com/streamich/react-use/blob/master/docs/createStateContext.md) — factory of hooks for a sharing state between components.~~ (Not planning to implement)
+#### createMemo
+
+No plans to implement
+
+#### createReducer
+
+No plans to implement
+
+#### createReducerContext
+
+No plans to implement
+
+#### createStateContext
+
+No plans to implement
+
 - [ ] [useDefault](https://github.com/streamich/react-use/blob/master/docs/useDefault.md) — returns the default value when state is null or undefined.
 - [ ] [useGetSet](https://github.com/streamich/react-use/blob/master/docs/useGetSet.md) — returns state getter get() instead of raw state.
 - [ ] [useGetSetState](https://github.com/streamich/react-use/blob/master/docs/useGetSetState.md) — as if useGetSet and useSetState had a baby.
@@ -143,7 +170,11 @@ See [our README](https://github.com/react-hookz/web).
 - [x] [useMediatedState](https://github.com/streamich/react-use/blob/master/docs/useMediatedState.md) — like the regular useState but with mediation by custom function. (Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate))
 - [x] [useFirstMountState](https://github.com/streamich/react-use/blob/master/docs/useFirstMountState.md) — check if current render is first. (Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate))
 - [ ] [useRendersCount](https://github.com/streamich/react-use/blob/master/docs/useRendersCount.md) — count component renders.
-- [ ] ~~[createGlobalState](https://github.com/streamich/react-use/blob/master/docs/createGlobalState.md) — cross component shared state.~~ (Not planning to implement)
+
+#### createGlobalState
+
+No plans to implement
+
 - [ ] [useMethods](https://github.com/streamich/react-use/blob/master/docs/useMethods.md) — neat alternative to useReducer.
 
 ### Miscellaneous

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -238,19 +238,93 @@ No API changes, besides name change.
 
 Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
 
-// TODO
+OLD in `react-use`:
+
+```javascript
+const { loading, value, error } = useAsync(async () => {
+  const response = await fetch(url);
+  const result = await response.text();
+  return result;
+}, [url]);
+
+console.log(loading);
+console.log(value);
+console.log(error.message);
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const [{ status, result, error }] = useAsync(async () => {
+  const response = await fetch(url);
+  const result = await response.text();
+  return result;
+}, [url]);
+
+console.log(status === "loading");
+console.log(result);
+console.log(error.message);
+```
 
 #### useAsyncFn
 
-Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+Implemented as part of [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
 
-// TODO
+OLD in `react-use`:
+
+```javascript
+const [{ loading, value, error }, doFetch] = useAsync(async () => {
+  const response = await fetch(url);
+  const result = await response.text();
+  return result;
+}, [url]);
+
+doFetch();
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const [{ status, result, error }, { execute }] = useAsync(
+  async () => {
+    const response = await fetch(url);
+    const result = await response.text();
+    return result;
+  },
+  [url],
+  { skipMount: true, skipUpdate: true }
+);
+
+execute();
+```
 
 #### useAsyncRetry
 
-Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+Implemented as part of [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
 
-// TODO
+OLD in `react-use`:
+
+```javascript
+const { loading, value, error, retry } = useAsync(async () => {
+  const response = await fetch(url);
+  const result = await response.text();
+  return result;
+}, [url]);
+
+retry();
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const [{ status, result, error }, { execute }] = useAsync(async () => {
+  const response = await fetch(url);
+  const result = await response.text();
+  return result;
+}, [url]);
+
+execute();
+```
 
 #### useBeforeUnload
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -234,17 +234,23 @@ No API changes, besides name change.
 
 ### Side-effects
 
-#### useAsync and useAsyncFn and useAsyncRetry
+#### useAsync
 
 Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+
+// TODO
 
 #### useAsyncFn
 
 Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
 
+// TODO
+
 #### useAsyncRetry
 
 Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+
+// TODO
 
 #### useBeforeUnload
 
@@ -287,7 +293,7 @@ Not implemented yet
 
 `@react-hookz/web` has three options for debouncing, which we feel are both more ergonomic and flexible than `react-use`'s implementation.
 
-Implemented as [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback)
+Depending on your use case, [useDebouncedEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-usedebouncedeffect), [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback), or [useDebouncedState](https://react-hookz.github.io/web/?path=/docs/state-usedebouncedstate) may be more appropriate.
 
 #### useError
 
@@ -301,6 +307,10 @@ Not implemented yet
 
 Implemented as [useLocalStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue)
 
+Backwards compatiable API, minus the `raw` option.
+
+NOTE: `useLocalStorage` instances with the same key on the same page are synchronised. This synchronisation does not work across tabs or on changes that are triggered by third-party code.
+
 #### useLockBodyScroll
 
 Not implemented yet
@@ -313,17 +323,27 @@ Not implemented yet
 
 Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue)
 
+Backwards compatiable API, minus the `raw` option.
+
+NOTE: `useSessionStorage` instances with the same key on the same page are synchronised. This synchronisation does not work across tabs or on changes that are triggered by third-party code.
+
 #### useThrottle and useThrottleFn
 
 `@react-hookz/web` has three options for throttling, which we feel are both more ergonomic and flexible than `react-use`'s implementations.
+
+Depending on your use case, [useThrottledEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-usethrottledeffect), [useThrottledCallback](https://react-hookz.github.io/web/?path=/docs/callback-usethrottledcallback), or [useThrottledState](https://react-hookz.github.io/web/?path=/docs/state-usethrottledstate) may be more appropriate.
 
 #### useTitle
 
 Implemented as [useDocumentTitle](https://react-hookz.github.io/web/?path=/docs/dom-usedocumenttitle)
 
+Backwards compatiable API.
+
 #### usePermission
 
 Implemented as [usePermission](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission)
+
+No API changes.
 
 ### Lifecycles
 
@@ -334,6 +354,32 @@ No plans to implement
 #### useEvent
 
 Implemented as [useEventListener](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener)
+
+OLD in `react-use`:
+
+```javascript
+useEvent(
+  "mousemove",
+  () => {
+    setState(new Date());
+  },
+  window,
+  { passive: true }
+);
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+useEventListener(
+  window,
+  "mousemove",
+  () => {
+    setState(new Date());
+  },
+  { passive: true }
+);
+```
 
 #### useLifecycles
 

--- a/migrating-from-react-use.md
+++ b/migrating-from-react-use.md
@@ -1,0 +1,17 @@
+# Migrating from `react-use`
+
+One of `@react-hookz/web`'s primary goals is to replace [react-use](https://github.com/streamich/react-use), the no longer maintained project `@react-hookz/web` grew out of.
+
+## A note on missing hooks
+
+Many of `react-use`'s hooks have already been ported to `@react-hookz/web`. You can track our work in [this issue](https://github.com/react-hookz/web/issues/33).
+
+If there is a `react-use` hook you need that isn't ported yet, please comment there - or even better, make a PR!
+
+In the mean time, **feel free to use both `@react-hookz/web` and `react-use` in tandem**.
+
+## Installation
+
+See [our README](https://github.com/react-hookz/web).
+
+## Migrating Hooks

--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -14,7 +14,7 @@ In the mean time, **feel free to use both `@react-hookz/web` and `react-use` in 
 
 ## Installation
 
-See [our README](https://react-hookz.github.io/web/?path=/docs/home).
+See [our README](/docs/home--page).
 
 ## Migrating Hooks
 
@@ -78,7 +78,7 @@ Not implemented yet
 
 #### useMedia
 
-Implemented as [useMediaQuery](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery)
+Implemented as [useMediaQuery](/docs/sensor-usemediaquery--example)
 
 No API changes, besides name change.
 
@@ -104,7 +104,7 @@ Not implemented yet
 
 #### useNetworkState
 
-Implemented as [useNetwork](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork)
+Implemented as [useNetwork](/docs/navigator-usenetwork--example)
 
 No API changes, besides name change.
 
@@ -142,13 +142,13 @@ Not implemented yet
 
 #### useMeasure
 
-Implemented as [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure)
+Implemented as [useMeasure](/docs/sensor-usemeasure--example)
 
 No API changes.
 
 #### useSize
 
-Use [useMeasure](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure) instead.
+Use [useMeasure](/docs/sensor-usemeasure--example) instead.
 
 #### createBreakpoint
 
@@ -166,7 +166,7 @@ Not implemented yet
 
 #### useClickAway
 
-Implmented as [useClickOutside](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside))
+Implmented as [useClickOutside](/docs/dom-useclickoutside--example))
 
 No API changes, besides name change.
 
@@ -230,7 +230,7 @@ Not implemented yet
 
 #### useUpdate
 
-Implemented as [useRerender](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRerender)
+Implemented as [useRerender](/docs/lifecycle-useRerender--example)
 
 No API changes, besides name change.
 
@@ -238,7 +238,7 @@ No API changes, besides name change.
 
 #### useAsync
 
-Implemented as [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+Implemented as [useAsync](/docs/side-effect-useasync--example)
 
 OLD in `react-use`:
 
@@ -270,7 +270,7 @@ console.log(error.message);
 
 #### useAsyncFn
 
-Implemented as part of [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+Implemented as part of [useAsync](/docs/side-effect-useasync--example)
 
 OLD in `react-use`:
 
@@ -302,7 +302,7 @@ execute();
 
 #### useAsyncRetry
 
-Implemented as part of [useAsync](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
+Implemented as part of [useAsync](/docs/side-effect-useasync--example)
 
 OLD in `react-use`:
 
@@ -334,7 +334,7 @@ Not implemented yet
 
 #### useCookie
 
-Implemented as [useCookieValue](https://react-hookz.github.io/web/?path=/docs/side-effect-useCookieValue)
+Implemented as [useCookieValue](/docs/side-effect-useCookieValue--example)
 
 OLD in `react-use`:
 
@@ -369,7 +369,7 @@ Not implemented yet
 
 `@react-hookz/web` has three options for debouncing, which we feel are both more ergonomic and flexible than `react-use`'s implementation.
 
-Depending on your use case, [useDebouncedEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-usedebouncedeffect), [useDebounceCallback](https://react-hookz.github.io/web/?path=/docs/callback-usedebouncecallback), or [useDebouncedState](https://react-hookz.github.io/web/?path=/docs/state-usedebouncedstate) may be more appropriate.
+Depending on your use case, [useDebouncedEffect](/docs/lifecycle-usedebouncedeffect--example), [useDebounceCallback](/docs/callback-usedebouncecallback--example), or [useDebouncedState](/docs/state-usedebouncedstate--example) may be more appropriate.
 
 #### useError
 
@@ -381,7 +381,7 @@ Not implemented yet
 
 #### useLocalStorage
 
-Implemented as [useLocalStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue)
+Implemented as [useLocalStorageValue](/docs/side-effect-uselocalstoragevalue--example)
 
 Backwards compatiable API, minus the `raw` option.
 
@@ -397,7 +397,7 @@ Not implemented yet
 
 #### useSessionStorage
 
-Implemented as [useSessionStorageValue](https://react-hookz.github.io/web/?path=/docs/side-effect-usesessionstoragevalue)
+Implemented as [useSessionStorageValue](/docs/side-effect-usesessionstoragevalue--example)
 
 Backwards compatiable API, minus the `raw` option.
 
@@ -407,17 +407,17 @@ NOTE: `useSessionStorage` instances with the same key on the same page are synch
 
 `@react-hookz/web` has three options for throttling, which we feel are both more ergonomic and flexible than `react-use`'s implementations.
 
-Depending on your use case, [useThrottledEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-usethrottledeffect), [useThrottledCallback](https://react-hookz.github.io/web/?path=/docs/callback-usethrottledcallback), or [useThrottledState](https://react-hookz.github.io/web/?path=/docs/state-usethrottledstate) may be more appropriate.
+Depending on your use case, [useThrottledEffect](/docs/lifecycle-usethrottledeffect--example), [useThrottledCallback](/docs/callback-usethrottledcallback--example), or [useThrottledState](/docs/state-usethrottledstate--example) may be more appropriate.
 
 #### useTitle
 
-Implemented as [useDocumentTitle](https://react-hookz.github.io/web/?path=/docs/dom-usedocumenttitle)
+Implemented as [useDocumentTitle](/docs/dom-usedocumenttitle--example)
 
 Backwards compatiable API.
 
 #### usePermission
 
-Implemented as [usePermission](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission)
+Implemented as [usePermission](/docs/navigator-usepermission--example)
 
 No API changes.
 
@@ -429,7 +429,7 @@ No plans to implement
 
 #### useEvent
 
-Implemented as [useEventListener](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener)
+Implemented as [useEventListener](/docs/dom-useeventlistener--example)
 
 OLD in `react-use`:
 
@@ -463,7 +463,7 @@ No plans to implement
 
 #### useMountedState
 
-Implemented as [useIsMounted](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsMounted)
+Implemented as [useIsMounted](/docs/lifecycle-useIsMounted--example)
 
 No API change, besides name change.
 
@@ -481,25 +481,25 @@ Not implemented yet
 
 #### useMount
 
-Implemented as [useMountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useMountEffect)
+Implemented as [useMountEffect](/docs/lifecycle-useMountEffect--example)
 
 No API change, besides name change.
 
 #### useUnmount
 
-Implemented as [useUnmountEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUnmountEffect)
+Implemented as [useUnmountEffect](/docs/lifecycle-useUnmountEffect--example)
 
 No API change, besides name change.
 
 #### useUpdateEffect
 
-Implemented as [useUpdateEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useUpdateEffect)
+Implemented as [useUpdateEffect](/docs/lifecycle-useUpdateEffect--example)
 
 No API change.
 
 #### useIsomorphicLayoutEffect
 
-Implemented as [useIsomorphicLayoutEffect](https://react-hookz.github.io/web/?path=/docs/lifecycle-useIsomorphicLayoutEffect)
+Implemented as [useIsomorphicLayoutEffect](/docs/lifecycle-useIsomorphicLayoutEffect--example)
 
 No API changes.
 
@@ -547,13 +547,13 @@ Not implemented yet
 
 #### useLatest
 
-Implemented as [useSynchedRef](https://react-hookz.github.io/web/?path=/docs/miscellaneous-usesyncedref)
+Implemented as [useSynchedRef](/docs/miscellaneous-usesyncedref--example)
 
 No API changes, besides name change.
 
 #### usePrevious
 
-Implemented as [usePrevious](https://react-hookz.github.io/web/?path=/docs/state-useprevious)
+Implemented as [usePrevious](/docs/state-useprevious--example)
 
 No API changes.
 
@@ -579,13 +579,13 @@ Not implemented yet
 
 #### useToggle
 
-Implemented as [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle)
+Implemented as [useToggle](/docs/state-usetoggle--example)
 
 No API changes.
 
 #### useBoolean
 
-Use [useToggle](https://react-hookz.github.io/web/?path=/docs/state-usetoggle) instead
+Use [useToggle](/docs/state-usetoggle--example) instead
 
 #### useCounter
 
@@ -605,7 +605,7 @@ Not implemented yet
 
 #### useMap
 
-Implemented as [useMap](https://react-hookz.github.io/web/?path=/docs/state-usemap)
+Implemented as [useMap](/docs/state-usemap--example)
 
 OLD in `react-use`:
 
@@ -642,7 +642,7 @@ NOTES: `@react-hookz/web`'s implementation is the same signature as the native `
 
 #### useSet
 
-Implemented as [useSet](https://react-hookz.github.io/web/?path=/docs/state-useset)
+Implemented as [useSet](/docs/state-useset--example)
 
 OLD in `react-use`:
 
@@ -692,7 +692,7 @@ Not implemented yet
 
 #### useMediatedState
 
-Implemented as [useMediatedState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemediatedstate)
+Implemented as [useMediatedState](/docs/lifecycle-usemediatedstate--example)
 
 OLD in `react-use`:
 
@@ -714,7 +714,7 @@ setState("Hello world!");
 
 #### useFirstMountState
 
-Implemented as [useFirstMountState](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate)
+Implemented as [useFirstMountState](/docs/lifecycle-usefirstmountstate--example)
 
 No API changes.
 

--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -1,4 +1,6 @@
-# Migrating from `react-use`
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Migrating from react-use" />
 
 One of `@react-hookz/web`'s primary goals is to replace [react-use](https://github.com/streamich/react-use), the no longer maintained project `@react-hookz/web` grew out of.
 
@@ -12,7 +14,7 @@ In the mean time, **feel free to use both `@react-hookz/web` and `react-use` in 
 
 ## Installation
 
-See [our README](https://github.com/react-hookz/web).
+See [our README](https://react-hookz.github.io/web/?path=/docs/home).
 
 ## Migrating Hooks
 


### PR DESCRIPTION
## What is the problem?

A lot of our users are coming from `react-use`. A migration guide might help them move quicker.

## What changes does this PR make to fix the problem?

I created a migration guide.

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
