### PR TITLE
fix: remove `useCookieValue` from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,6 @@ export { useSyncedRef } from './useSyncedRef/useSyncedRef';
 // SideEffect
 export { useLocalStorageValue } from './useLocalStorageValue/useLocalStorageValue';
 export { useSessionStorageValue } from './useSessionStorageValue/useSessionStorageValue';
-export { useCookieValue, IUseCookieValueReturn } from './useCookieValue/useCookieValue';
 export {
   useAsync,
   IAsyncState,

--- a/src/useCookieValue/__docs__/story.mdx
+++ b/src/useCookieValue/__docs__/story.mdx
@@ -8,6 +8,8 @@ import { Example } from './example.stories';
 Manages a single cookie.
 
 > Requires installation of `js-cookie` package.
+> **Should be directly imported as it has optional dependency and therefore it is not exported from
+> index file**
 
 - Uses `js-cookie` package underneath.
 - SSR-friendly.

--- a/src/useCookieValue/__tests__/dom.ts
+++ b/src/useCookieValue/__tests__/dom.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { act, renderHook } from '@testing-library/react-hooks/dom';
 import * as Cookies from 'js-cookie';
-import { IUseCookieValueReturn, useCookieValue } from '../..';
+import { IUseCookieValueReturn, useCookieValue } from '../useCookieValue';
 import SpyInstance = jest.SpyInstance;
 
 describe('useCookieValue', () => {

--- a/src/useCookieValue/__tests__/ssr.ts
+++ b/src/useCookieValue/__tests__/ssr.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks/server';
-import { useCookieValue } from '../..';
+import { useCookieValue } from '../useCookieValue';
 
 describe('useCookieValue', () => {
   it('should be defined', () => {


### PR DESCRIPTION
Because of optional dependency it would break the build in case of `js-cookie` absence.

BREAKING CHANGE: `useCookieValue` is no more exported from index file.

## What new hook does?

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
