### PR TITLE
fix(useMediaQuery): add support for safari 13-

### DIFF
--- a/src/useMediaQuery/__tests__/dom.ts
+++ b/src/useMediaQuery/__tests__/dom.ts
@@ -13,16 +13,7 @@ describe('useMediaQuery', () => {
     dispatchEvent: jest.Mock;
   };
 
-  const matchMediaMock = jest.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  }));
+  const matchMediaMock = jest.fn();
   let initialMatchMedia: typeof window.matchMedia;
 
   beforeAll(() => {
@@ -35,6 +26,19 @@ describe('useMediaQuery', () => {
 
   afterAll(() => {
     window.matchMedia = initialMatchMedia;
+  });
+
+  beforeEach(() => {
+    matchMediaMock.mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // Deprecated
+      removeListener: jest.fn(), // Deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
   });
 
   afterEach(() => {
@@ -133,5 +137,24 @@ describe('useMediaQuery', () => {
     expect(mql.removeEventListener).not.toHaveBeenCalled();
     unmount1();
     expect(mql.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use addListener and removeListener in case of absence of modern methods', () => {
+    matchMediaMock.mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    const { unmount } = renderHook(() => useMediaQuery('max-width : 1024px'));
+
+    const mql = matchMediaMock.mock.results[0].value as IMutableMediaQueryList;
+    expect(mql.addListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(mql.removeListener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/useMediaQuery/useMediaQuery.ts
+++ b/src/useMediaQuery/useMediaQuery.ts
@@ -18,7 +18,8 @@ const querySubscribe = (query: string, dispatch: Dispatch<boolean>) => {
       });
     };
 
-    mql.addEventListener('change', listener, { passive: true });
+    if (mql.addEventListener) mql.addEventListener('change', listener, { passive: true });
+    else mql.addListener(listener);
 
     entry = {
       mql,
@@ -43,7 +44,9 @@ const queryUnsubscribe = (query: string, dispatch: Dispatch<boolean>): void => {
 
     if (!dispatchers.size) {
       queriesMap.delete(query);
-      mql.removeEventListener('change', listener);
+
+      if (mql.removeEventListener) mql.removeEventListener('change', listener);
+      else mql.removeListener(listener);
     }
   }
 };


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

As Safari 13- has obsolete MediaQueryList API - it requires some extra checks.

### What is the expected behavior?

Shpould Work on safari 13-

### How does this PR fix the problem?

Check `addEventListener` and `removeEventListener` methods existence and fallback to `addListener` and `removeListener` respectively.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - Close: #242 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
