### PR TITLE
docs: fix typo in useMeasure docs

### DIFF
--- a/src/useMeasure/__docs__/story.mdx
+++ b/src/useMeasure/__docs__/story.mdx
@@ -28,4 +28,4 @@ function useMeasure<T extends Element>(): [DOMRectReadOnly | undefined, RefObjec
 Array of two elements:
 
 - **0** _`DOMRectReadOnly | undefined`_ - Current element rect, received from ResizeObserver;
-- **1** _`RefObject<T>`_ - Ref objet that should be passed to tracked element;
+- **1** _`RefObject<T>`_ - Ref object that should be passed to tracked element;


### PR DESCRIPTION
## What is the problem?

There was a small typo in the `useMeasure` docs

## What changes does this PR make to fix the problem?

Fixes the typo

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
