### PR TITLE
docs: fix typo in `useIntersectionObserver` docs

### DIFF
--- a/src/useIntersectionObserver/__docs__/story.mdx
+++ b/src/useIntersectionObserver/__docs__/story.mdx
@@ -31,7 +31,7 @@ export function useIntersectionObserver<T extends Element>(
 
 - **target** _`RefObject<T> | T | null`_ - React reference or Element to track.
 - **options** - Like `IntersectionObserver` options but `root` can also be react reference.
-  - **threshold** _`RefObject<Element | Document> | Element | Document | null`_
+  - **root** _`RefObject<Element | Document> | Element | Document | null`_
     _(default: `document`)_ - An `Element` or `Document` object (or its react reference) which is
     an ancestor of the intended target, whose bounding rectangle will be considered the viewport.
     Any part of the target not visible in the visible area of the root is not considered visible.


### PR DESCRIPTION
## What is the problem?

There was a typo in the `useIntersectionObserver` docs

## What changes does this PR make to fix the problem?

Fixes the typo

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
