### PR TITLE
docs: update migration guide with `useIntersectionObserver` and `useKeyboardEvent`

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -70,19 +70,19 @@ const intersection = useIntersectionObserver(elementRef, {
 
 #### useKey
 
-Not implemented yet
+See [useKeyboardEvent](https://react-hookz.github.io/web/?path=/docs/dom-usekeyboardevent--example)
 
 #### useKeyPress
 
-Not implemented yet
+See [useKeyboardEvent](https://react-hookz.github.io/web/?path=/docs/dom-usekeyboardevent--example)
 
 #### useKeyboardJs
 
-Not implemented yet
+See [useKeyboardEvent](https://react-hookz.github.io/web/?path=/docs/dom-usekeyboardevent--example)
 
 #### useKeyPressEvent
 
-Not implemented yet
+See [useKeyboardEvent](https://react-hookz.github.io/web/?path=/docs/dom-usekeyboardevent--example)
 
 #### useLocation
 

--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -46,7 +46,27 @@ Not implemented yet
 
 #### useIntersection
 
-Not implemented yet
+Implemented as [useIntersectionObserver](/docs/sensor-useintersectionobserver--example)
+
+OLD in `react-use`:
+
+```javascript
+const intersection = useIntersection(elementRef, {
+  root: rootRef,
+  rootMargin: '0px',
+  threshold: 1,
+});
+```
+
+NEW in `@react-hookz/web`:
+
+```javascript
+const intersection = useIntersectionObserver(elementRef, {
+  root: rootRef,
+  rootMargin: '0px',
+  threshold: [0, 0.5],
+});
+```
 
 #### useKey
 


### PR DESCRIPTION
## What is the problem?

The migration guide was outdated

## What changes does this PR make to fix the problem?

Updated migration guide with `useIntersectionObserver` and `useKeyboardEvent`

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
