### PR TITLE
docs(useNetworkState): proper hook naming in docs

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -124,7 +124,7 @@ Not implemented yet
 
 #### useNetworkState
 
-Implemented as [useNetwork](/docs/navigator-usenetwork--example)
+Implemented as [useNetworkState](/docs/navigator-usenetworkstate--example)
 
 No API changes, besides name change.
 

--- a/src/useNetworkState/__docs__/story.mdx
+++ b/src/useNetworkState/__docs__/story.mdx
@@ -1,9 +1,9 @@
 import { Example } from './example.stories';
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title={'Navigator/useNetwork'} component={Example} />
+<Meta title={'Navigator/useNetworkState'} component={Example} />
 
-# useNetwork
+# useNetworkState
 
 Tracks the state of browser's network connection.
 


### PR DESCRIPTION
## What is the problem?

Invalid hook name in docs, aslthough it is properly named in code.
Fixes #251 

## What changes does this PR make to fix the problem?

## Checklist

- [x] Is there an existing issue for this PR?
  - #251 
