### PR TITLE
feat(useAsync): remove effector behaviour from hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ export {
   IAsyncStatus,
   IUseAsyncActions,
   IUseAsyncMeta,
-  IUseAsyncOptions,
 } from './useAsync/useAsync';
 
 // Sensor

--- a/src/useAsync/__docs__/example.stories.tsx
+++ b/src/useAsync/__docs__/example.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useAsync } from '../..';
+import { useAsync, useMountEffect } from '../..';
 
 export const Example: React.FC = () => {
   const [state, actions] = useAsync(
@@ -9,8 +9,10 @@ export const Example: React.FC = () => {
           resolve('react-hookz is awesome!');
         }, 3000);
       }),
-    []
+    'react-hookz is'
   );
+
+  useMountEffect(actions.execute);
 
   return (
     <div>

--- a/src/useAsync/__docs__/story.mdx
+++ b/src/useAsync/__docs__/story.mdx
@@ -26,21 +26,15 @@ Executes provided async function and tracks its result and error.
 ```ts
 export function useAsync<Result, Args extends unknown[] = unknown[]>(
   asyncFn: (...params: Args) => Promise<Result>,
-  args: Args,
-  options?: IUseAsyncOptions<Result>
+  initialValue?: Result
 ): [IAsyncState<Result>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>];
 ```
 
 #### Arguments
 
 - **asyncFn** _`(...params: Args) => Promise<Result>`_ - Function that returns a promise.
-- **args** _`Args`_ - Arguments list that will be passed to async function. Acts as dependencies
-  list for underlying `useEffect` hook.
-- **options** - Hook options:
-  - **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation,
-    before the async function is executed.
-  - **skipMount** _`boolean`_ _(default: `false`)_ - Skip mount async function execution.
-  - **skipUpdate** _`boolean`_ _(default: `false`)_ - Skip update async function execution.
+- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation,
+  before the async function is executed.
 
 #### Return
 

--- a/src/useAsync/__tests__/ssr.ts
+++ b/src/useAsync/__tests__/ssr.ts
@@ -7,7 +7,7 @@ describe('useAsync', () => {
   });
 
   it('should render', () => {
-    const { result } = renderHook(() => useAsync(async () => {}, []));
+    const { result } = renderHook(() => useAsync(async () => {}));
     expect(result.error).toBeUndefined();
   });
 });

--- a/src/useAsync/useAsync.ts
+++ b/src/useAsync/useAsync.ts
@@ -25,22 +25,6 @@ export type IAsyncState<Result> =
       result: Result;
     };
 
-export interface IUseAsyncOptions<Result> {
-  /**
-   * Value that will be set on initialisation, before the async function is
-   * executed.
-   */
-  initialValue?: Result;
-  /**
-   * Skip mount async function execution.
-   */
-  skipMount?: boolean;
-  /**
-   * Skip update async function execution.
-   */
-  skipUpdate?: boolean;
-}
-
 export interface IUseAsyncActions<Result, Args extends unknown[] = unknown[]> {
   /**
    * Reset state to initial, when async function haven't been executed.


### PR DESCRIPTION
Use composition with effectors for such functionality.

BREAKING CHANGE:
`useAsync` hook now has only 2 arguments, `asyncFn` and `initialValue`
and do not execute provided function on its own.

### How does this PR fix the problem?
Remove effector functionality and unnecessary arguments.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #317 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
