### PR TITLE
feat: new hook `useAsyncAbortable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Coming from `react-use`? Check out our [migration guide](https://react-hookz.git
 
   - [**`useAsync`**](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync)
     — Executes provided async function and tracks its result and error.
+  - [**`useAsyncAbortable`**](https://react-hookz.github.io/web/?path=/docs/side-effect-useasyncabortable)
+    — Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.
   - [**`useCookieValue`**](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookievalue)
     — Manages a single cookie.
   - [**`useLocalStorageValue`**](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue)

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,12 @@ export {
   IUseAsyncActions,
   IUseAsyncMeta,
 } from './useAsync/useAsync';
+export {
+  useAsyncAbortable,
+  IUseAsyncAbortableActions,
+  IUseAsyncAbortableMeta,
+  IArgsWithAbortSignal,
+} from './useAsyncAbortable/useAsyncAbortable';
 
 // Sensor
 export {

--- a/src/useAsync/__docs__/example.stories.tsx
+++ b/src/useAsync/__docs__/example.stories.tsx
@@ -24,7 +24,13 @@ export const Example: React.FC = () => {
       <div>current value: {state.result ?? 'undefined'}</div>
       <br />
       <div>
-        <button onClick={actions.reset}>reset</button>{' '}
+        <button
+          onClick={() => {
+            actions.reset();
+            actions.execute();
+          }}>
+          reset
+        </button>{' '}
         <button onClick={actions.execute}>execute</button>
       </div>
     </div>

--- a/src/useAsync/__docs__/story.mdx
+++ b/src/useAsync/__docs__/story.mdx
@@ -5,15 +5,13 @@ import { Example } from './example.stories';
 
 # useAsync
 
-Executes provided async function and tracks its result and error.
+Tracks result and error of provided async function and provides handles to execute and reset it.
 
 - Handles any async functions.
 - Safe - no worries about updating the state of unmounted component.
 - Stable - returned methods do not change between renders.
 - Handles race conditions - only latest results are stored in state.
-- SSR-friendly, no requests performed on the server.
-- Provides methods to manually trigger fetch.
-- Options to customize behaviour.
+- Provides methods to manually trigger execution or reset state to initial.
 
 #### Example
 
@@ -38,14 +36,19 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
 
 #### Return
 
-0. **state**
+1. **state**
+
    - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - latest promise status.
    - **result** _`Result | undefined`_ - promise result if promise fulfilled.
    - **error** _`Error | undefined`_ - promise error if promise rejected.
+
 1. **methods**
+
    - **reset** _`() => void`_- Reset state to initial, when async function haven't been executed.
    - **execute** _`(...args: Args) => Promise<Result>`_- Execute async function manually.
-2. **meta**
+
+1. **meta**
+
    - **promise** _`Promise<Result> | undefined`_- Recent promise returned from async function.
    - **lastArgs** _`Args | undefined`_ - List of arguments applied to recent async function
      invocation.

--- a/src/useAsync/useAsync.ts
+++ b/src/useAsync/useAsync.ts
@@ -52,11 +52,12 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
   initialValue: Result
 ): [IAsyncState<Result>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>];
 export function useAsync<Result, Args extends unknown[] = unknown[]>(
-  asyncFn: (...params: Args) => Promise<Result>
+  asyncFn: (...params: Args) => Promise<Result>,
+  initialValue?: Result
 ): [IAsyncState<Result | undefined>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>];
 
 /**
- * Executes provided async function and tracks its result and error.
+ * Tracks result and error of provided async function and provides handles to execute and reset it.
  *
  * @param asyncFn Function that returns a promise.
  * @param initialValue Value that will be set on initialisation, before the async function is
@@ -82,7 +83,7 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
 
       setState((s) => ({ ...s, status: 'loading' }));
 
-      promiseRef.current.then(
+      promise.then(
         (result) => {
           // we dont want to handle result/error of non-latest function
           // this approach helps to avoid race conditions
@@ -99,7 +100,7 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
         }
       );
 
-      return promiseRef.current;
+      return promise;
     },
     reset: () => {
       setState({

--- a/src/useAsyncAbortable/__docs__/example.stories.tsx
+++ b/src/useAsyncAbortable/__docs__/example.stories.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { useAsyncAbortable, useMountEffect } from '../..';
+
+export const Example: React.FC = () => {
+  const [state, actions, meta] = useAsyncAbortable(
+    (signal) =>
+      new Promise<string>((resolve, reject) => {
+        setTimeout(() => {
+          if (signal.aborted) {
+            reject(new Error('Aborted!'));
+          } else {
+            resolve('react-hookz is awesome!');
+          }
+        }, 5000);
+      }),
+    'react-hookz is'
+  );
+
+  useMountEffect(actions.execute);
+
+  return (
+    <div>
+      <div>
+        <em>
+          Async function will resolve after 5 seconds of wait. In case of abort - promise will be
+          rejected.
+        </em>
+      </div>
+      <br />
+      <div>promise status: {state.status}</div>
+      <div>current value: {state.result ?? 'undefined'}</div>
+      <div>error: {state.error ? state.error.message : 'undefined'}</div>
+      <br />
+      <div>
+        <button onClick={actions.abort} disabled={!meta.abortController}>
+          abort
+        </button>{' '}
+        <button
+          onClick={() => {
+            actions.reset();
+            actions.execute();
+          }}>
+          reset & execute
+        </button>{' '}
+        <button onClick={actions.execute}>execute</button>
+      </div>
+    </div>
+  );
+};

--- a/src/useAsyncAbortable/__docs__/example.stories.tsx
+++ b/src/useAsyncAbortable/__docs__/example.stories.tsx
@@ -22,8 +22,8 @@ export const Example: React.FC = () => {
     <div>
       <div>
         <em>
-          Async function will resolve after 5 seconds of wait. In case of abort - promise will be
-          rejected.
+          Async function will resolve after 5 seconds. If the function is aborted, the promise will
+          be rejected.
         </em>
       </div>
       <br />

--- a/src/useAsyncAbortable/__docs__/story.mdx
+++ b/src/useAsyncAbortable/__docs__/story.mdx
@@ -1,0 +1,61 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Example } from './example.stories';
+
+<Meta title="Side-effect/useAsyncAbortable" component={Example} />
+
+# useAsyncAbortable
+
+Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.
+
+- All the advantages of `useAsync`
+- Automatically aborts previously invoked async.
+- Provides `abort` handle.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
+  asyncFn: (...params: IArgsWithAbortSignal<Args>) => Promise<Result>,
+  initialValue?: Result
+): [
+  IAsyncState<Result | undefined>,
+  IUseAsyncAbortableActions<Result, Args>,
+  IUseAsyncAbortableMeta<Result, Args>
+];
+```
+
+#### Arguments
+
+- **asyncFn** _`(...params: IArgsWithAbortSignal<Args>) => Promise<Result>`_ - Function that returns
+  a promise.
+- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation,
+  before the async function is executed.
+
+#### Return
+
+1. **state**
+
+   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - latest promise status.
+   - **result** _`Result | undefined`_ - promise result if promise fulfilled.
+   - **error** _`Error | undefined`_ - promise error if promise rejected.
+
+1. **methods**
+
+   - **reset** _`() => void`_- Abort currently running async and reset state to initial, when async
+     function haven't been executed.
+   - **execute** _`(...args: Args) => Promise<Result>`_- Execute async function manually.
+   - **abort** _`() => void`_- Abort currently running async.
+
+1. **meta**
+
+   - **promise** _`Promise<Result> | undefined`_- Recent promise returned from async function.
+   - **lastArgs** _`Args | undefined`_ - List of arguments applied to recent async function
+     invocation.
+   - **abortController** _`AbortController | undefined`_ - Current abort controller. New one created
+     each async execution.

--- a/src/useAsyncAbortable/__docs__/story.mdx
+++ b/src/useAsyncAbortable/__docs__/story.mdx
@@ -41,9 +41,9 @@ export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
 
 1. **state**
 
-   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - latest promise status.
-   - **result** _`Result | undefined`_ - promise result if promise fulfilled.
-   - **error** _`Error | undefined`_ - promise error if promise rejected.
+   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - Latest promise status.
+   - **result** _`Result | undefined`_ - Promise result if promise fulfilled.
+   - **error** _`Error | undefined`_ - Promise error if promise rejected.
 
 1. **methods**
 

--- a/src/useAsyncAbortable/__tests__/dom.ts
+++ b/src/useAsyncAbortable/__tests__/dom.ts
@@ -1,0 +1,138 @@
+import { act, renderHook } from '@testing-library/react-hooks/dom';
+import { useAsyncAbortable } from '../..';
+
+describe('useAsyncAbortable', () => {
+  function getControllableAsync<Res, Args extends unknown[] = unknown[]>() {
+    const resolve: { current: undefined | ((result: Res) => void) } = { current: undefined };
+    const reject: { current: undefined | ((err: Error) => void) } = { current: undefined };
+
+    return [
+      jest.fn(
+        (...args: Args) =>
+          new Promise<Res>((res, rej) => {
+            resolve.current = res;
+            reject.current = rej;
+          })
+      ),
+      resolve,
+      reject,
+    ] as const;
+  }
+
+  it('should be defined', () => {
+    expect(useAsyncAbortable).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useAsyncAbortable(async (_) => {}));
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should not change methods between renders', () => {
+    const spy = jest.fn(async () => {});
+    const { rerender, result } = renderHook(() => useAsyncAbortable(spy));
+
+    const res1 = result.current;
+    rerender();
+
+    expect(res1[1].execute).toBe(result.current[1].execute);
+    expect(res1[1].reset).toBe(result.current[1].reset);
+    expect(res1[1].abort).toBe(result.current[1].abort);
+  });
+
+  it('should pass abort signal as first argument', async () => {
+    const spy = jest.fn(async (s: AbortSignal, n: number) => n);
+    const { result } = renderHook(() => useAsyncAbortable(spy));
+
+    await act(async () => {
+      result.current[1].execute(123);
+    });
+
+    expect(spy.mock.calls[0][0]).toBeInstanceOf(AbortSignal);
+    expect(spy.mock.calls[0][0].aborted).toBe(false);
+    expect(spy.mock.calls[0][1]).toBe(123);
+
+    expect(result.current[0]).toStrictEqual({
+      status: 'success',
+      error: undefined,
+      result: 123,
+    });
+  });
+
+  it('should abort signal in case of actions.abort call', async () => {
+    const [spy, resolve] = getControllableAsync<number, [AbortSignal, number]>();
+    const { result } = renderHook(() => useAsyncAbortable(spy));
+
+    await act(async () => {
+      result.current[1].execute(123);
+    });
+
+    result.current[1].abort();
+
+    expect(spy.mock.calls[0][0].aborted).toBe(true);
+
+    await act(async () => {
+      if (resolve.current) {
+        resolve.current(123);
+      }
+    });
+  });
+
+  it('should also abort signal in case of actions.reset call', async () => {
+    const [spy, resolve] = getControllableAsync<number, [AbortSignal, number]>();
+    const { result } = renderHook(() => useAsyncAbortable(spy, 321));
+
+    await act(async () => {
+      result.current[1].execute(123);
+    });
+
+    await act(async () => {
+      result.current[1].reset();
+    });
+
+    expect(spy.mock.calls[0][0].aborted).toBe(true);
+
+    expect(result.current[0]).toStrictEqual({
+      status: 'not-executed',
+      error: undefined,
+      result: 321,
+    });
+
+    await act(async () => {
+      if (resolve.current) {
+        resolve.current(123);
+      }
+    });
+  });
+
+  it('should abort previous async in case new one executed before first resolution', async () => {
+    const [spy, resolve] = getControllableAsync<number, [AbortSignal, number]>();
+    const { result } = renderHook(() => useAsyncAbortable(spy, 321));
+
+    await act(async () => {
+      result.current[1].execute(123);
+    });
+
+    const resolve1 = resolve.current;
+
+    await act(async () => {
+      result.current[1].execute(1234);
+    });
+
+    expect(spy.mock.calls[0][1]).toBe(123);
+    expect(spy.mock.calls[0][0].aborted).toBe(true);
+
+    expect(spy.mock.calls[1][1]).toBe(1234);
+    expect(spy.mock.calls[1][0].aborted).toBe(false);
+
+    await act(async () => {
+      if (resolve1) {
+        resolve1(123);
+      }
+
+      if (resolve.current) {
+        resolve.current(1234);
+      }
+    });
+  });
+});

--- a/src/useAsyncAbortable/__tests__/ssr.ts
+++ b/src/useAsyncAbortable/__tests__/ssr.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useAsyncAbortable } from '../..';
+
+describe('useAsyncAbortable', () => {
+  it('should be defined', () => {
+    expect(useAsyncAbortable).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useAsyncAbortable(async (_) => {}));
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/useAsyncAbortable/useAsyncAbortable.ts
+++ b/src/useAsyncAbortable/useAsyncAbortable.ts
@@ -1,0 +1,101 @@
+import { useMemo, useRef } from 'react';
+import { IAsyncState, IUseAsyncActions, IUseAsyncMeta, useAsync } from '..';
+
+export interface IUseAsyncAbortableActions<Result, Args extends unknown[] = unknown[]>
+  extends IUseAsyncActions<Result, Args> {
+  /**
+   *  Abort currently running async.
+   */
+  abort: () => void;
+
+  /**
+   * Abort currently running async and reset state to initial, when async function haven't been executed.
+   */
+  reset: () => void;
+}
+
+export interface IUseAsyncAbortableMeta<Result, Args extends unknown[] = unknown[]>
+  extends IUseAsyncMeta<Result, Args> {
+  /**
+   * Current abort controller. New one created each async execution.
+   */
+  abortController: AbortController | undefined;
+}
+
+export type IArgsWithAbortSignal<Args extends unknown[] = unknown[]> = [AbortSignal, ...Args];
+
+export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
+  asyncFn: (...params: IArgsWithAbortSignal<Args>) => Promise<Result>,
+  initialValue: Result
+): [
+  IAsyncState<Result>,
+  IUseAsyncAbortableActions<Result, Args>,
+  IUseAsyncAbortableMeta<Result, Args>
+];
+export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
+  asyncFn: (...params: IArgsWithAbortSignal<Args>) => Promise<Result>,
+  initialValue?: Result
+): [
+  IAsyncState<Result | undefined>,
+  IUseAsyncAbortableActions<Result, Args>,
+  IUseAsyncAbortableMeta<Result, Args>
+];
+
+/**
+ * Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.
+ *
+ * @param asyncFn Function that returns a promise.
+ * @param initialValue Value that will be set on initialisation, before the async function is
+ * executed.
+ */
+export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
+  asyncFn: (...params: IArgsWithAbortSignal<Args>) => Promise<Result>,
+  initialValue?: Result
+): [
+  IAsyncState<Result | undefined>,
+  IUseAsyncAbortableActions<Result, Args>,
+  IUseAsyncAbortableMeta<Result, Args>
+] {
+  const abortController = useRef<AbortController>();
+
+  const fn = async (...args: Args): Promise<Result> => {
+    // abort previous async
+    abortController.current?.abort();
+
+    // create new controller for ongoing async call
+    const ac = new AbortController();
+    abortController.current = ac;
+
+    // pass down abort signal and received arguments
+    return asyncFn(ac.signal, ...args).finally(() => {
+      // unset ref uf the call is last
+      if (abortController.current === ac) {
+        abortController.current = undefined;
+      }
+    });
+  };
+
+  const [state, asyncActions, asyncMeta] = useAsync<Result, Args>(fn, initialValue);
+
+  return [
+    state,
+    useMemo(() => {
+      const actions = {
+        reset: () => {
+          actions.abort();
+          asyncActions.reset();
+        },
+        abort: () => {
+          abortController.current?.abort();
+        },
+      };
+
+      return {
+        ...asyncActions,
+        ...actions,
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []),
+    { ...asyncMeta, abortController: abortController.current },
+  ];
+}

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -22,9 +22,6 @@ export function off<T extends EventTarget>(
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type PartialRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const hasOwnProperty = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What new hook does?

Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
