### PR TITLE
docs: includes example import statements on all docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ our [migration guide](https://react-hookz.github.io/web/?path=/docs/migrating-fr
 - #### State
 
   - [**`useDebouncedState`**](https://react-hookz.github.io/web/?path=/docs/state-usedebouncedstate--example)
-    — Lise `useSafeState` but its state setter is debounced.
+    — Like `useSafeState` but its state setter is debounced.
   - [**`useMap`**](https://react-hookz.github.io/web/?path=/docs/state-usemap--example)
     — Tracks the state of a `Map`.
   - [**`useMediatedState`**](https://react-hookz.github.io/web/?path=/docs/state-usemediatedstate--example)

--- a/src/storybookUtil/ImportPath.tsx
+++ b/src/storybookUtil/ImportPath.tsx
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { DocsContext, Source } from '@storybook/addon-docs/blocks';
+import React, { useContext } from 'react';
+
+export const ImportPath = (): JSX.Element => {
+  const context = useContext(DocsContext);
+  const componentName = context.kind?.split('/')[1];
+
+  const path = `
+import { ${componentName} } from '@react-hookz/web'; // cjs
+import { ${componentName} } from '@react-hookz/web/esm'; // esm
+import { ${componentName} } from '@react-hookz/web/esnext' // esnext
+  `;
+
+  return <Source language="js" code={path} />;
+};

--- a/src/useAsync/__docs__/story.mdx
+++ b/src/useAsync/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Side-effect/useAsync" component={Example} />
 
@@ -27,6 +28,10 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
   initialValue?: Result
 ): [IAsyncState<Result>, IUseAsyncActions<Result, Args>, IUseAsyncMeta<Result, Args>];
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useAsyncAbortable/__docs__/story.mdx
+++ b/src/useAsyncAbortable/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Side-effect/useAsyncAbortable" component={Example} />
 
@@ -29,6 +30,10 @@ export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
   IUseAsyncAbortableMeta<Result, Args>
 ];
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useClickOutside/__docs__/story.mdx
+++ b/src/useClickOutside/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="DOM/useClickOutside" component={Example} />
 
@@ -27,6 +28,10 @@ export function useClickOutside<T extends HTMLElement>(
   events: string[] = DEFAULT_EVENTS
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useConditionalEffect/__docs__/story.mdx
+++ b/src/useConditionalEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useConditionalEffect" component={Example} />
 
@@ -35,6 +36,10 @@ export function useConditionalEffect<
   ...effectHookRestArgs: R
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useCookieValue/__docs__/story.mdx
+++ b/src/useCookieValue/__docs__/story.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta, Story, Source } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
 
 <Meta title="Side-effect/useCookieValue" component={Example} />
@@ -7,9 +7,10 @@ import { Example } from './example.stories';
 
 Manages a single cookie.
 
-> Requires installation of `js-cookie` package.
-> **Should be directly imported as it has optional dependency and therefore it is not exported from
-> index file**
+> **IMPORTANT**: Requires separate installation of `js-cookie` package.
+
+> **IMPORTANT**: This hook should be directly imported as it has optional dependency and therefore it is not exported from
+> index file. See [importing](#importing) section below.
 
 - Uses `js-cookie` package underneath.
 - SSR-friendly.
@@ -49,6 +50,17 @@ export type IUseCookieReturn = [
 
 export function useCookieValue(key: string, options: IUseCookieOptions = {}): IUseCookieReturn;
 ```
+
+#### Importing
+
+<Source
+  language="js"
+  code={`
+import { useCookieValue } from '@react-hookz/web/cjs/useCookieValue/useCookieValue'; // cjs
+import { useCookieValue } from '@react-hookz/web/esm/useCookieValue/useCookieValue'; // esm
+import { useCookieValue } from '@react-hookz/web/esnext/useCookieValue/useCookieValue' // esnext
+`}
+/>
 
 #### Arguments
 

--- a/src/useCustomCompareEffect/__docs__/story.mdx
+++ b/src/useCustomCompareEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useCustomCompareEffect" component={Example} />
 
@@ -32,6 +33,10 @@ export function useCustomCompareEffect<
   ...effectHookRestArgs: R
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useDebouncedCallback/__docs__/story.mdx
+++ b/src/useDebouncedCallback/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Callback/useDebouncedCallback" component={Example} />
 
@@ -31,6 +32,12 @@ export function useDebouncedCallback<Args extends any[], This>(
   maxWait = 0
 ): IDebouncedFunction<Args, This>;
 ```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
 
 - **callback** _`(...args: T) => unknown`_ - function that will be debounced.
 - **deps** _`React.DependencyList`_ - dependencies list when to update callback.

--- a/src/useDebouncedEffect/__docs__/story.mdx
+++ b/src/useDebouncedEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useDebouncedEffect" component={Example} />
 
@@ -23,6 +24,10 @@ export function useDebouncedEffect(
   maxWait = 0
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useDebouncedState/__docs__/story.mdx
+++ b/src/useDebouncedState/__docs__/story.mdx
@@ -1,11 +1,12 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useDebouncedState" component={Example} />
 
 # useDebouncedState
 
-Lise `useSafeState` but its state setter is debounced.
+Like `useSafeState` but its state setter is debounced.
 
 #### Example
 
@@ -22,6 +23,10 @@ export function useDebouncedState<S>(
   maxWait = 0
 ): [S, Dispatch<SetStateAction<S>>];
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useDebouncedState/useDebouncedState.ts
+++ b/src/useDebouncedState/useDebouncedState.ts
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { useDebouncedCallback, useSafeState } from '..';
 
 /**
- * Lise `useSafeState` but its state setter is debounced.
+ * Like `useSafeState` but its state setter is debounced.
  *
  * @param initialState Initial state to pass to underlying `useSafeState`.
  * @param delay Debounce delay.

--- a/src/useDocumentTitle/__docs__/story.mdx
+++ b/src/useDocumentTitle/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Dom/useDocumentTitle" component={Example} />
 
@@ -31,6 +32,10 @@ export interface IUseDocumentTitleOptions {
 
 function useDocumentTitle(title: string, options: Partial<IUseDocumentTitleOptions> = {}): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useEventListener/__docs__/story.mdx
+++ b/src/useEventListener/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Dom/useEventListener" component={Example} />
 
@@ -28,6 +29,10 @@ export function useEventListener<T extends EventTarget>(
     | [string, EventListenerOrEventListenerObject, ...any]
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useFirstMountState/__docs__/story.mdx
+++ b/src/useFirstMountState/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story, Typeset } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useFirstMountState" component={Example} />
 
@@ -18,6 +19,10 @@ Return boolean that is `true` only on first render.
 ```ts
 function useFirstMountState(): boolean;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Return
 

--- a/src/useIntersectionObserver/__docs__/story.mdx
+++ b/src/useIntersectionObserver/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Sensor/useIntersectionObserver" component={Example} />
 
@@ -26,6 +27,10 @@ export function useIntersectionObserver<T extends Element>(
   { threshold = [0], root, rootMargin = '0px' }: IUseIntersectionObserverOptions = {}
 ): IntersectionObserverEntry | undefined;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useIsMounted/__docs__/story.mdx
+++ b/src/useIsMounted/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useIsMounted" component={Example} />
 
@@ -21,6 +22,10 @@ This hook is handy for the cases when you have to detect component mount state w
 ```ts
 function useIsMounted(): () => boolean;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Return
 

--- a/src/useKeyboardEvent/__docs__/story.mdx
+++ b/src/useKeyboardEvent/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="DOM/useKeyboardEvent" component={Example} />
 
@@ -23,6 +24,10 @@ export function useKeyboardEvent<T extends EventTarget>(
   options: IUseKeyboardEventOptions<T> = {}
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -1,4 +1,5 @@
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 <Meta title="Side-effect/useLocalStorageValue" component={Example} />
@@ -44,6 +45,10 @@ function useLocalStorageValue<T>(
   options: IUseStorageValueOptions<T> = {}
 ): IHookReturn<T, typeof defaultValue, typeof options>;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useMap/__docs__/story.mdx
+++ b/src/useMap/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useMap" component={Example} />
 
@@ -24,6 +25,10 @@ Tracks the state of a `Map`.
 ```ts
 export function useMap<K = any, V = any>(entries?: readonly (readonly [K, V])[] | null): Map<K, V>;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useMeasure/__docs__/story.mdx
+++ b/src/useMeasure/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Sensor/useMeasure" />
 
@@ -22,6 +23,10 @@ Uses ResizeObserver to track element dimensions and re-render component when the
 ```ts
 function useMeasure<T extends Element>(): [DOMRectReadOnly | undefined, RefObject<T>];
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Return
 

--- a/src/useMediaQuery/__docs__/story.mdx
+++ b/src/useMediaQuery/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Sensor/useMediaQuery" component={Example} />
 
@@ -23,6 +24,10 @@ Tracks the state of CSS media query.
 ```ts
 export function useMediaQuery(query: string): boolean | undefined;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useMediatedState/__docs__/story.mdx
+++ b/src/useMediatedState/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useMediatedState" component={Example} />
 
@@ -27,3 +28,7 @@ function useMediatedState<S, R>(
   mediator?: (state: R) => S
 ): [S, (value: R | ((prevState: S) => R)) => void];
 ```
+
+#### Importing
+
+<ImportPath />

--- a/src/useMountEffect/__docs__/story.mdx
+++ b/src/useMountEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useMountEffect" component={Example} />
 
@@ -21,6 +22,10 @@ Run effect only when component is first mounted.
 ```ts
 function useMountEffect(effect: CallableFunction): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useNetworkState/__docs__/story.mdx
+++ b/src/useNetworkState/__docs__/story.mdx
@@ -1,4 +1,5 @@
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 <Meta title={'Navigator/useNetworkState'} component={Example} />
@@ -42,6 +43,10 @@ export interface IUseNetworkState {
 
 export function useNetworkState(initialState?: IInitialState<IUseNetworkState>): IUseNetworkState;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/usePermission/__docs__/story.mdx
+++ b/src/usePermission/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Navigator/usePermission" component={Example} />
 
@@ -21,6 +22,10 @@ Tracks a permission state.
 ```ts
 export function usePermission(descriptor: IAnyPermissionDescriptor): IUsePermissionState;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/usePrevious/__docs__/story.mdx
+++ b/src/usePrevious/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/usePrevious" component={Example} />
 
@@ -18,6 +19,10 @@ Returns the value passed to the hook on previous render.
 ```ts
 function usePrevious<T>(value?: T): T | undefined;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useRafCallback/__docs__/story.mdx
+++ b/src/useRafCallback/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Callback/useRafCallback" component={Example} />
 
@@ -26,6 +27,12 @@ export function useRafCallback<T extends (...args: any[]) => any>(
   cb: T
 ): [(...args: Parameters<T>) => void, () => void];
 ```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
 
 - **cb** _`(...args: T) => any`_ - function that will be invoked within animation frame.
 

--- a/src/useRerender/__docs__/story.mdx
+++ b/src/useRerender/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useRerender" component={Example} />
 
@@ -20,6 +21,10 @@ Return callback function that re-renders component.
 ```ts
 function useRerender(): () => void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Return
 

--- a/src/useResizeObserver/__docs__/story.mdx
+++ b/src/useResizeObserver/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example, ExampleDebounced } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Sensor/useResizeObserver" />
 
@@ -35,6 +36,10 @@ export function useResizeObserver<T extends Element>(
   callback: (entry: ResizeObserverEntry) => void
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -1,4 +1,5 @@
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 <Meta title="Side-effect/useSessionStorageValue" component={Example} />
@@ -44,6 +45,10 @@ function useSessionStorageValue<T>(
   options: IUseStorageValueOptions<T> = {}
 ): IHookReturn<T, typeof defaultValue, typeof options>;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useSet/__docs__/story.mdx
+++ b/src/useSet/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useSet" component={Example} />
 
@@ -24,6 +25,10 @@ Tracks the state of a `Set`.
 ```ts
 export function useSet<T = any>(values?: readonly T[] | null): Set<T>;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useSyncedRef/__docs__/story.mdx
+++ b/src/useSyncedRef/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Miscellaneous/useSyncedRef" component={Example} />
 
@@ -32,6 +33,10 @@ Like `useRef`, but it returns immutable ref that contains actual value.
 ```ts
 function useSyncedRef<T>(value: T): { readonly current: T };
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useThrottledCallback/__docs__/story.mdx
+++ b/src/useThrottledCallback/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Callback/useThrottledCallback" component={Example} />
 
@@ -30,6 +31,10 @@ export function useThrottledCallback<Args extends any[], This>(
   noTrailing = false
 ): IThrottledFunction<Args, This>;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useThrottledEffect/__docs__/story.mdx
+++ b/src/useThrottledEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useThrottledEffect" component={Example} />
 
@@ -23,6 +24,10 @@ export function useThrottledEffect(
   noTrailing = false
 ): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useThrottledState/__docs__/story.mdx
+++ b/src/useThrottledState/__docs__/story.mdx
@@ -1,11 +1,12 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useThrottledState" component={Example} />
 
 # useThrottledState
 
-Lise `useSafeState` but its state setter is throttled.
+Like `useSafeState` but its state setter is throttled.
 
 #### Example
 
@@ -22,6 +23,10 @@ export function useThrottledState<S>(
   noTrailing = false
 ): [S, Dispatch<SetStateAction<S>>];
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useToggle/__docs__/story.mdx
+++ b/src/useToggle/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useToggle" component={Example} />
 
@@ -22,6 +23,10 @@ function useToggle(
   initialState: IInitialState<boolean> = false
 ): [boolean, (nextState?: INewState<boolean>) => void];
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useUnmountEffect/__docs__/story.mdx
+++ b/src/useUnmountEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useUnmountEffect" component={Example} />
 
@@ -18,6 +19,10 @@ Run effect only when component is unmounted.
 ```ts
 function useUnmountEffect(effect: CallableFunction): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useUpdateEffect/__docs__/story.mdx
+++ b/src/useUpdateEffect/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="Lifecycle/useUpdateEffect" component={Example} />
 
@@ -18,6 +19,10 @@ Effect hook that ignores the first render (not invoked on mount)
 ```ts
 function useUpdateEffect(effect: React.EffectCallback, deps?: React.DependencyList): void;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/src/useValidator/__docs__/story.mdx
+++ b/src/useValidator/__docs__/story.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="State/useValidator" component={Example} />
 
@@ -36,6 +37,10 @@ function useValidator<V extends IValidityState>(
   initialValidity: IInitialState<V> = { isValid: undefined } as V
 ) => IUseValidatorReturn<V>;
 ```
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 

--- a/utility/add-new-hook.js
+++ b/utility/add-new-hook.js
@@ -49,6 +49,7 @@ export const Example: React.FC = () => {
     path.resolve(hookDir, `__docs__/story.mdx`),
     `import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
 
 <Meta title="New Hook/${hookName}" component={Example} />
 
@@ -65,6 +66,10 @@ import { Example } from './example.stories';
 \`\`\`ts
 
 \`\`\`
+
+#### Importing
+
+<ImportPath />
 
 #### Arguments
 


### PR DESCRIPTION
## What is the problem?

Improve docs UX by adding import statements on all docs pages

## What changes does this PR make to fix the problem?

- Includes example import statements on all docs pages
- Clarify's `useCookieValue`'s imports
- Fixes some typos

## Checklist

- closes #319 
