### PR TITLE
docs: fix `useDebouncedCallback` and `useThrottledCallback` docs

### DIFF
--- a/src/useDebouncedCallback/__docs__/story.mdx
+++ b/src/useDebouncedCallback/__docs__/story.mdx
@@ -6,15 +6,16 @@ import { ImportPath } from '../../storybookUtil/ImportPath';
 
 # useDebouncedCallback
 
-The third argument is a list of dependencies, as for `useCallback`.
+Makes passed function debounced, otherwise acts like `useCallback`.  
+[What is debouncing?](https://css-tricks.com/debouncing-throttling-explained-examples/#debounce)
 
-> The third argument is dependencies list on `useEffect` manner, passed function will be re-wrapped
-> when delay or dependencies has changed. Changed debounce callbacks still has same timeout, meaning
-> that calling new debounced function will abort previously scheduled invocation.
+The third argument is dependencies list on `useCallback` manner, passed function will be re-wrapped
+when delay or dependencies has changed. Changed debounce callbacks still has same timeout, meaning
+that calling new debounced function will abort previously scheduled invocation.
 
-> Debounced function is always a void function since original callback invoked later.
+Debounced function is always a void function since original callback invoked later.
 
-> Deferred execution automatically cancelled on component unmount.
+Deferred execution automatically cancelled on component unmount.
 
 #### Example
 

--- a/src/useThrottledCallback/__docs__/story.mdx
+++ b/src/useThrottledCallback/__docs__/story.mdx
@@ -7,13 +7,13 @@ import { ImportPath } from '../../storybookUtil/ImportPath';
 # useThrottledCallback
 
 Makes passed function throttled, otherwise acts like `useCallback`.  
-[\[What is throttling?\]](https://css-tricks.com/debouncing-throttling-explained-examples/#throttle)
+[What is throttling?](https://css-tricks.com/debouncing-throttling-explained-examples/#throttle)
 
-> The third argument is dependencies list in `useEffect` manner, passed function will be re-wrapped
-> when delay or dependencies has changed. Changed throttle callbacks still have same timeout, meaning
-> that calling new throttled function will abort previously scheduled invocation.
+The third argument is dependencies list in `useCallback` manner, passed function will be re-wrapped
+when delay or dependencies has changed. Changed throttle callbacks still have same timeout, meaning
+that calling new throttled function will abort previously scheduled invocation.
 
-> Throttled function is always a void function since original callback invoked later.
+Throttled function is always a void function since original callback invoked later.
 
 #### Example
 


### PR DESCRIPTION
## What is the problem?

`useDebouncedCallback` and `useThrottledCallback` docs mention `useEffect` hooks.

## What changes does this PR make to fix the problem?

Cleans up those docs

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
