### PR TITLE
fix(`useLocalStorage`, `useSessionStorage`): replace hook with noop in case of storage absence.

### DIFF
--- a/src/useLocalStorageValue/useLocalStorageValue.ts
+++ b/src/useLocalStorageValue/useLocalStorageValue.ts
@@ -10,6 +10,8 @@ let IS_LOCAL_STORAGE_AVAILABLE = false;
 try {
   IS_LOCAL_STORAGE_AVAILABLE = isBrowser && !!window.localStorage;
 } catch {
+  // no need to test this flag leads to noop behaviour
+  /* istanbul ignore next */
   IS_LOCAL_STORAGE_AVAILABLE = false;
 }
 
@@ -64,6 +66,7 @@ export const useLocalStorageValue: IUseLocalStorageValue = IS_LOCAL_STORAGE_AVAI
       defaultValue: T | null = null,
       options: IUseStorageValueOptions = {}
     ): IHookReturn<T, typeof defaultValue, typeof options> => {
+      /* istanbul ignore next */
       if (isBrowser && process.env.NODE_ENV === 'development') {
         console.warn('LocalStorage is not available in this environment');
       }

--- a/src/useLocalStorageValue/useLocalStorageValue.ts
+++ b/src/useLocalStorageValue/useLocalStorageValue.ts
@@ -3,35 +3,47 @@ import {
   IUseStorageValueOptions,
   useStorageValue,
 } from '../useStorageValue/useStorageValue';
-import { isBrowser } from '../util/const';
+import { isBrowser, noop } from '../util/const';
 
-export function useLocalStorageValue<T = unknown>(
-  key: string,
-  defaultValue?: null,
-  options?: IUseStorageValueOptions
-): IHookReturn<T, typeof defaultValue, IUseStorageValueOptions<true | undefined>>;
-export function useLocalStorageValue<T = unknown>(
-  key: string,
-  defaultValue: null,
-  options: IUseStorageValueOptions<false>
-): IHookReturn<T, typeof defaultValue, typeof options>;
+let IS_LOCAL_STORAGE_AVAILABLE = false;
 
-export function useLocalStorageValue<T>(
-  key: string,
-  defaultValue: T,
-  options?: IUseStorageValueOptions
-): IHookReturn<T, typeof defaultValue, IUseStorageValueOptions<true | undefined>>;
-export function useLocalStorageValue<T>(
-  key: string,
-  defaultValue: T,
-  options: IUseStorageValueOptions<false>
-): IHookReturn<T, typeof defaultValue, typeof options>;
+try {
+  IS_LOCAL_STORAGE_AVAILABLE = isBrowser && !!window.localStorage;
+} catch {
+  IS_LOCAL_STORAGE_AVAILABLE = false;
+}
 
-export function useLocalStorageValue<T>(
-  key: string,
-  defaultValue?: T | null,
-  options?: IUseStorageValueOptions
-): IHookReturn<T, typeof defaultValue, typeof options>;
+interface IUseLocalStorageValue {
+  <T = unknown>(key: string, defaultValue?: null, options?: IUseStorageValueOptions): IHookReturn<
+    T,
+    typeof defaultValue,
+    IUseStorageValueOptions<true | undefined>
+  >;
+
+  <T = unknown>(
+    key: string,
+    defaultValue: null,
+    options: IUseStorageValueOptions<false>
+  ): IHookReturn<T, typeof defaultValue, typeof options>;
+
+  <T>(key: string, defaultValue: T, options?: IUseStorageValueOptions): IHookReturn<
+    T,
+    typeof defaultValue,
+    IUseStorageValueOptions<true | undefined>
+  >;
+
+  <T>(key: string, defaultValue: T, options: IUseStorageValueOptions<false>): IHookReturn<
+    T,
+    typeof defaultValue,
+    typeof options
+  >;
+
+  <T>(key: string, defaultValue?: T | null, options?: IUseStorageValueOptions): IHookReturn<
+    T,
+    typeof defaultValue,
+    typeof options
+  >;
+}
 
 /**
  * Manages a single localStorage key.
@@ -40,10 +52,21 @@ export function useLocalStorageValue<T>(
  * @param defaultValue Default value to yield in case the key is not in storage
  * @param options
  */
-export function useLocalStorageValue<T>(
-  key: string,
-  defaultValue: T | null = null,
-  options: IUseStorageValueOptions = {}
-): IHookReturn<T, typeof defaultValue, typeof options> {
-  return useStorageValue(isBrowser ? localStorage : ({} as Storage), key, defaultValue, options);
-}
+export const useLocalStorageValue: IUseLocalStorageValue = IS_LOCAL_STORAGE_AVAILABLE
+  ? <T>(
+      key: string,
+      defaultValue: T | null = null,
+      options: IUseStorageValueOptions = {}
+    ): IHookReturn<T, typeof defaultValue, typeof options> =>
+      useStorageValue(isBrowser ? localStorage : ({} as Storage), key, defaultValue, options)
+  : <T>(
+      key: string,
+      defaultValue: T | null = null,
+      options: IUseStorageValueOptions = {}
+    ): IHookReturn<T, typeof defaultValue, typeof options> => {
+      if (isBrowser && process.env.NODE_ENV === 'development') {
+        console.warn('LocalStorage is not available in this environment');
+      }
+
+      return [undefined, noop, noop, noop];
+    };

--- a/src/useSessionStorageValue/useSessionStorageValue.ts
+++ b/src/useSessionStorageValue/useSessionStorageValue.ts
@@ -10,6 +10,8 @@ let IS_SESSION_STORAGE_AVAILABLE = false;
 try {
   IS_SESSION_STORAGE_AVAILABLE = isBrowser && !!window.sessionStorage;
 } catch {
+  // no need to test this flag leads to noop behaviour
+  /* istanbul ignore next */
   IS_SESSION_STORAGE_AVAILABLE = false;
 }
 
@@ -64,6 +66,7 @@ export const useSessionStorageValue: IUseSessionStorageValue = IS_SESSION_STORAG
       defaultValue: T | null = null,
       options: IUseStorageValueOptions = {}
     ): IHookReturn<T, typeof defaultValue, typeof options> => {
+      /* istanbul ignore next */
       if (isBrowser && process.env.NODE_ENV === 'development') {
         console.warn('SessionStorage is not available in this environment');
       }


### PR DESCRIPTION
### How does this PR fix the problem?

Adds storage access check to replace hook with noop functionality.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #521
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
