### PR TITLE
docs(useDefault): Suggest `useMediatedState` instead 

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -567,7 +567,18 @@ No plans to implement
 
 #### useDefault
 
-Not implemented yet
+No plans to implement, rather use [useMediatedState](/docs/state-useMediatedState--example) like
+so:
+
+```javascript
+const initialValue = 'world';
+const defaultValue = 'you';
+const [greeting, setGreeting] = useMediatedState(
+  initialValue,
+  (newValue) => newValue ?? defaultValue
+);
+console.log(`Hello ${greeting}`);
+```
 
 #### useGetSet
 


### PR DESCRIPTION
## What new hook does?

It works like `useSafeState`, except it will return the provided default value when the state is set to `undefined` or `null`.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  - #33 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
