### PR TITLE
feat: new hook `usePreviousDistinct`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export { useDebouncedState } from './useDebouncedState/useDebouncedState';
 export { useMap } from './useMap/useMap';
 export { useMediatedState } from './useMediatedState/useMediatedState';
 export { usePrevious } from './usePrevious/usePrevious';
+export { usePreviousDistinct } from './usePreviousDistinct/usePreviousDistinct';
 export { useSafeState } from './useSafeState/useSafeState';
 export { useSet } from './useSet/useSet';
 export { useToggle } from './useToggle/useToggle';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { useDebouncedState } from './useDebouncedState/useDebouncedState';
 export { useMap } from './useMap/useMap';
 export { useMediatedState } from './useMediatedState/useMediatedState';
 export { usePrevious } from './usePrevious/usePrevious';
-export { usePreviousDistinct, TPredicate } from './usePreviousDistinct/usePreviousDistinct';
+export { usePreviousDistinct, Predicate } from './usePreviousDistinct/usePreviousDistinct';
 export { useSafeState } from './useSafeState/useSafeState';
 export { useSet } from './useSet/useSet';
 export { useToggle } from './useToggle/useToggle';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { useDebouncedState } from './useDebouncedState/useDebouncedState';
 export { useMap } from './useMap/useMap';
 export { useMediatedState } from './useMediatedState/useMediatedState';
 export { usePrevious } from './usePrevious/usePrevious';
-export { usePreviousDistinct } from './usePreviousDistinct/usePreviousDistinct';
+export { usePreviousDistinct, TPredicate } from './usePreviousDistinct/usePreviousDistinct';
 export { useSafeState } from './useSafeState/useSafeState';
 export { useSet } from './useSet/useSet';
 export { useToggle } from './useToggle/useToggle';

--- a/src/usePrevious/__docs__/example.stories.tsx
+++ b/src/usePrevious/__docs__/example.stories.tsx
@@ -2,25 +2,30 @@ import React, { useState } from 'react';
 import { usePrevious } from '../..';
 
 export const Example: React.FC = () => {
-  const [val, setVal] = useState(0);
-  const prevVal = usePrevious(val);
+  const [value, setValue] = useState(0);
+  const [unrelatedValue, setUnrelatedValue] = useState(0);
+  const previousValue = usePrevious(value);
+
+  const increment = () => setValue((v) => v + 1);
+  const decrement = () => setValue((v) => v - 1);
+  const triggerUnrelatedRerender = () => setUnrelatedValue((v) => v + 1);
 
   return (
     <div>
-      <span>Current value: {val}</span>{' '}
-      <button
-        onClick={() => {
-          setVal((v) => v + 1);
-        }}>
-        increment
-      </button>{' '}
-      <button
-        onClick={() => {
-          setVal((v) => v - 1);
-        }}>
-        decrement
-      </button>
-      <div>Previous value: &quot;{prevVal ?? 'undefined'}&quot;</div>
+      <span>Current value: {value}</span>
+
+      <div style={{ margin: '1rem 0' }}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <button onClick={increment}>increment</button>
+          <button onClick={decrement}>decrement</button>
+        </div>
+
+        <button onClick={triggerUnrelatedRerender}>
+          trigger unrelated rerender - {unrelatedValue}
+        </button>
+      </div>
+
+      <div>Previous value: &quot;{previousValue ?? 'undefined'}&quot;</div>
     </div>
   );
 };

--- a/src/usePrevious/__docs__/story.mdx
+++ b/src/usePrevious/__docs__/story.mdx
@@ -6,7 +6,10 @@ import { ImportPath } from '../../storybookUtil/ImportPath';
 
 # usePrevious
 
-Returns the value passed to the hook on previous render.
+Returns the value passed to the hook on previous render. It is important to note that any renders
+will cause an update if the value has changed. This is useful for keeping track of state changes;
+however, if your desire is to track distinctly different values, you should use
+[`usePreviousDistinct`](/docs/state-usepreviousdistinct--example).
 
 #### Example
 
@@ -26,7 +29,7 @@ function usePrevious<T>(value?: T): T | undefined;
 
 #### Arguments
 
-- _**value**_ _`any`_ - the value that will be returned on next render
+- _**value**_ _`T (any)`_ - the value that will be returned on next render
 
 #### Return
 

--- a/src/usePrevious/__tests__/dom.ts
+++ b/src/usePrevious/__tests__/dom.ts
@@ -32,4 +32,14 @@ describe('usePrevious', () => {
     rerender({ state: 25 });
     expect(result.current).toBe(10);
   });
+
+  it('should return passed value after unrelated rerender', () => {
+    const { result, rerender } = renderHook(({ state }) => usePrevious(state), {
+      initialProps: { state: 0 },
+    });
+
+    expect(result.current).toBeUndefined();
+    rerender();
+    expect(result.current).toBe(0);
+  });
 });

--- a/src/usePreviousDistinct/__docs__/example.stories.tsx
+++ b/src/usePreviousDistinct/__docs__/example.stories.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { usePreviousDistinct } from '../..';
+
+export const Example: React.FC = () => {
+  const [value, setValue] = useState(0);
+  const [unrelatedValue, setUnrelatedValue] = useState(0);
+  const previousDistinctValue = usePreviousDistinct(value);
+
+  const increment = () => setValue((v) => v + 1);
+  const decrement = () => setValue((v) => v - 1);
+  const triggerUnrelatedRerender = () => setUnrelatedValue((v) => v + 1);
+
+  return (
+    <div>
+      <span>Current value: {value}</span>
+
+      <div style={{ margin: '1rem 0' }}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <button onClick={increment}>increment</button>
+          <button onClick={decrement}>decrement</button>
+        </div>
+
+        <button onClick={triggerUnrelatedRerender}>
+          trigger unrelated rerender - {unrelatedValue}
+        </button>
+      </div>
+
+      <div>Previous value: &quot;{previousDistinctValue ?? 'undefined'}&quot;</div>
+    </div>
+  );
+};

--- a/src/usePreviousDistinct/__docs__/story.mdx
+++ b/src/usePreviousDistinct/__docs__/story.mdx
@@ -8,7 +8,7 @@ import { ImportPath } from '../../storybookUtil/ImportPath';
 
 Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here means
 that the hook's return value will only update when the passed value updates. This is useful when
-other renders are involved potentially making multiple, irrelavant updates.
+other renders are involved potentially making multiple, irrelevant updates.
 
 #### Example
 
@@ -19,13 +19,13 @@ other renders are involved potentially making multiple, irrelavant updates.
 ## Reference
 
 ```ts
-export type Predicate<T> = (prev: T | undefined, next: T) => boolean;
+export type TPredicate<T> = (prev: T, next: any) => next is typeof prev;
 
-const checkIfStrictlyEqual = <T>(prev: T | undefined, next: T) => prev === next;
+const isStrictEqual = <T>(a: T, b: any): b is typeof a => a === b;
 
 export function usePreviousDistinct<T>(
   value: T,
-  compare: Predicate<T> = checkIfStrictlyEqual
+  predicate: Predicate<T> = isStrictEqual
 ): T | undefined;
 ```
 
@@ -35,11 +35,12 @@ export function usePreviousDistinct<T>(
 
 #### Arguments
 
-- _**value**_ _`T (any)`_ - the value that will be returned on next render
-- _**compare**_ _`Predicate<T> | undefined`_ - this comparison function will be called between renders to
-  determine if the value should be updated. If not provided, the value will be updated if it is
-  strictly equal (`===`) to the previous value.
+- _**value**_ _`T (any)`_ - Value to yield on next render if it's different from the previous one.
+- _**predicate**_ _`TPredicate<T> | undefined`_ - Optional predicate to determine if the value is
+  distinct. If not provided, the value will be updated if it is strictly equal (`===`) to the
+  previous value.
 
 #### Return
 
-Returns previously passed value or `undefined` for the case of first render.
+Returns previously passed value (if different from previous) or `undefined` for the case of first
+render.

--- a/src/usePreviousDistinct/__docs__/story.mdx
+++ b/src/usePreviousDistinct/__docs__/story.mdx
@@ -19,7 +19,7 @@ other renders are involved potentially making multiple, irrelevant updates.
 ## Reference
 
 ```ts
-export type TPredicate<T> = (prev: T, next: any) => next is typeof prev;
+export type Predicate<T> = (prev: T, next: any) => next is typeof prev;
 
 const isStrictEqual = <T>(a: T, b: any): b is typeof a => a === b;
 
@@ -36,7 +36,7 @@ export function usePreviousDistinct<T>(
 #### Arguments
 
 - _**value**_ _`T (any)`_ - Value to yield on next render if it's different from the previous one.
-- _**predicate**_ _`TPredicate<T> | undefined`_ - Optional predicate to determine if the value is
+- _**predicate**_ _`Predicate<T> | undefined`_ - Optional predicate to determine if the value is
   distinct. If not provided, the value will be updated if it is strictly equal (`===`) to the
   previous value.
 

--- a/src/usePreviousDistinct/__docs__/story.mdx
+++ b/src/usePreviousDistinct/__docs__/story.mdx
@@ -1,0 +1,45 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
+
+<Meta title="State/usePreviousDistinct" component={Example} />
+
+# usePreviousDistinct
+
+Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here means
+that the hook's return value will only update when the passed value updates. This is useful when
+other renders are involved potentially making multiple, irrelavant updates.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+export type Predicate<T> = (prev: T | undefined, next: T) => boolean;
+
+const checkIfStrictlyEqual = <T>(prev: T | undefined, next: T) => prev === next;
+
+export function usePreviousDistinct<T>(
+  value: T,
+  compare: Predicate<T> = checkIfStrictlyEqual
+): T | undefined;
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+- _**value**_ _`T (any)`_ - the value that will be returned on next render
+- _**compare**_ _`Predicate<T> | undefined`_ - this comparison function will be called between renders to
+  determine if the value should be updated. If not provided, the value will be updated if it is
+  strictly equal (`===`) to the previous value.
+
+#### Return
+
+Returns previously passed value or `undefined` for the case of first render.

--- a/src/usePreviousDistinct/__tests__/dom.ts
+++ b/src/usePreviousDistinct/__tests__/dom.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { usePreviousDistinct } from '../..';
+import { isStrictEqual } from '../../util/const';
 
 describe('usePreviousDistinct', () => {
   it('should be defined', () => {
@@ -17,14 +18,14 @@ describe('usePreviousDistinct', () => {
   });
 
   it('should return undefined on first render with compare function passed', () => {
-    const { result } = renderHook(() => usePreviousDistinct(0, (a, b) => a === b));
+    const { result } = renderHook(() => usePreviousDistinct(0, isStrictEqual));
     expect(result.current).toBeUndefined();
   });
 
   it('should not invoke predicate on first render', () => {
     const mockedCompare = jest.fn();
 
-    const { result } = renderHook(() => usePreviousDistinct(0, mockedCompare));
+    const { result } = renderHook(() => usePreviousDistinct(0, mockedCompare as any));
     expect(result.current).toBeUndefined();
     expect(mockedCompare).not.toHaveBeenCalled();
   });

--- a/src/usePreviousDistinct/__tests__/dom.ts
+++ b/src/usePreviousDistinct/__tests__/dom.ts
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { usePreviousDistinct } from '../..';
+
+describe('usePreviousDistinct', () => {
+  it('should be defined', () => {
+    expect(usePreviousDistinct).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => usePreviousDistinct(0));
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should return undefined on first render', () => {
+    const { result } = renderHook(() => usePreviousDistinct(0));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return undefined on first render with compare function passed', () => {
+    const { result } = renderHook(() => usePreviousDistinct(0, (a, b) => a === b));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should not invoke predicate on first render', () => {
+    const mockedCompare = jest.fn();
+
+    const { result } = renderHook(() => usePreviousDistinct(0, mockedCompare));
+    expect(result.current).toBeUndefined();
+    expect(mockedCompare).not.toHaveBeenCalled();
+  });
+
+  it('should not return passed value after unrelated rerender', () => {
+    const { result, rerender } = renderHook(({ state }) => usePreviousDistinct(state), {
+      initialProps: { state: 0 },
+    });
+
+    expect(result.current).toBeUndefined();
+    rerender();
+    expect(result.current).not.toBe(0);
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return passed value after related rerender', () => {
+    const { result, rerender } = renderHook(({ state }) => usePreviousDistinct(state), {
+      initialProps: { state: 0 },
+    });
+
+    expect(result.current).toBeUndefined(); // asserting against initial render.
+    rerender({ state: 1 });
+    expect(result.current).toBe(0); // asserting against first re-render. value has now changed
+  });
+
+  it('should update previous value only after render with different value', () => {
+    const { result, rerender } = renderHook(({ state }) => usePreviousDistinct(state), {
+      initialProps: { state: 0 },
+    });
+
+    expect(result.current).toBeUndefined();
+    rerender({ state: 1 }); // update
+    expect(result.current).toBe(0);
+    rerender({ state: 5 }); // update
+    expect(result.current).toBe(1);
+    rerender({ state: 5 }); // no update
+    expect(result.current).toBe(1);
+  });
+
+  it('should not update to value if it never changes, depsite rerenders', () => {
+    const value = 'yo';
+    const { result, rerender } = renderHook(({ state }) => usePreviousDistinct(state), {
+      initialProps: { state: value },
+    });
+
+    expect(result.current).toBeUndefined();
+    rerender({ state: value });
+    expect(result.current).toBeUndefined();
+    rerender({ state: value });
+    expect(result.current).toBeUndefined();
+    rerender({ state: value });
+  });
+});

--- a/src/usePreviousDistinct/__tests__/dom.ts
+++ b/src/usePreviousDistinct/__tests__/dom.ts
@@ -78,4 +78,21 @@ describe('usePreviousDistinct', () => {
     expect(result.current).toBeUndefined();
     rerender({ state: value });
   });
+
+  it('should update even when going between defined and undefined values', () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: number | undefined }) => usePreviousDistinct(state),
+      {
+        initialProps: { state: 0 } as { state: number | undefined },
+      }
+    );
+
+    expect(result.current).toBeUndefined();
+    rerender({ state: 1 });
+    expect(result.current).toBe(0);
+    rerender({ state: undefined });
+    expect(result.current).toBe(1);
+    rerender({ state: 10 });
+    expect(result.current).toBeUndefined();
+  });
 });

--- a/src/usePreviousDistinct/__tests__/ssr.ts
+++ b/src/usePreviousDistinct/__tests__/ssr.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks/server';
 import { usePreviousDistinct } from '../..';
+import { isStrictEqual } from '../../util/const';
 
 describe('usePreviousDistinct', () => {
   it('should be defined', () => {
@@ -18,7 +19,7 @@ describe('usePreviousDistinct', () => {
   });
 
   it('should return undefined on first render with compare function passed', () => {
-    const { result } = renderHook(() => usePreviousDistinct(0, (a, b) => a === b));
+    const { result } = renderHook(() => usePreviousDistinct(0, isStrictEqual));
 
     expect(result.current).toBeUndefined();
   });

--- a/src/usePreviousDistinct/__tests__/ssr.ts
+++ b/src/usePreviousDistinct/__tests__/ssr.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { usePreviousDistinct } from '../..';
+
+describe('usePreviousDistinct', () => {
+  it('should be defined', () => {
+    expect(usePreviousDistinct).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => usePreviousDistinct(0));
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should return undefined on first render', () => {
+    const { result } = renderHook(() => usePreviousDistinct(0));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return undefined on first render with compare function passed', () => {
+    const { result } = renderHook(() => usePreviousDistinct(0, (a, b) => a === b));
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/src/usePreviousDistinct/usePreviousDistinct.ts
+++ b/src/usePreviousDistinct/usePreviousDistinct.ts
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { useUpdateEffect } from '..';
 import { isStrictEqual } from '../util/const';
 
-export type TPredicate = <T>(prev: T, next: any) => next is typeof prev;
+export type TPredicate = <T>(prev: T, next: any) => boolean;
 
 /**
  * Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here

--- a/src/usePreviousDistinct/usePreviousDistinct.ts
+++ b/src/usePreviousDistinct/usePreviousDistinct.ts
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { useUpdateEffect } from '..';
 import { isStrictEqual } from '../util/const';
 
-export type TPredicate = <T>(prev: T, next: any) => boolean;
+export type Predicate = (prev: any, next: any) => boolean;
 
 /**
  * Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here
@@ -17,7 +17,7 @@ export type TPredicate = <T>(prev: T, next: any) => boolean;
  */
 export function usePreviousDistinct<T>(
   value: T,
-  predicate: TPredicate = isStrictEqual
+  predicate: Predicate = isStrictEqual
 ): T | undefined {
   const [previousState, setPreviousState] = useState<T>();
   const currentRef = useRef<T>(value);

--- a/src/usePreviousDistinct/usePreviousDistinct.ts
+++ b/src/usePreviousDistinct/usePreviousDistinct.ts
@@ -1,31 +1,39 @@
 import { useRef } from 'react';
-import { useFirstMountState } from '..';
+import { useCustomCompareEffect, useUpdateEffect } from '..';
+import { isStrictEqual } from '../util/const';
+import { basicDepsComparator } from '../util/misc';
 
-export type Predicate<T> = (prev: T | undefined, next: T) => boolean;
-
-const checkIfStrictlyEqual = <T>(prev: T | undefined, next: T) => prev === next;
+export type TPredicate = <T>(prev: T, next: any) => next is typeof prev;
 
 /**
  * Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here
  * means that the hook's return value will only update when the passed value updates. This is
- * useful when other renders are involved potentially making multiple, irrelavant updates.
+ * useful when other renders are involved potentially making multiple, irrelevant updates.
  *
  * Yields `undefined` on first render.
  *
- * @param value Value to yield on next render
+ * @param value Value to yield on next render if it's different from the previous one.
+ * @param predicate Optional predicate to determine if the value is distinct. If not provided,
+ * the value will be updated if it is strictly equal (`===`) to the previous value.
  */
 export function usePreviousDistinct<T>(
   value: T,
-  compare: Predicate<T> = checkIfStrictlyEqual
+  predicate: TPredicate = isStrictEqual
 ): T | undefined {
   const previousRef = useRef<T>();
   const currentRef = useRef<T>(value);
-  const isFirstMount = useFirstMountState();
 
-  if (!isFirstMount && !compare(currentRef.current, value)) {
-    previousRef.current = currentRef.current;
-    currentRef.current = value;
-  }
+  useCustomCompareEffect(
+    () => {
+      if (!predicate(currentRef.current, value)) {
+        previousRef.current = currentRef.current;
+        currentRef.current = value;
+      }
+    },
+    [value],
+    basicDepsComparator,
+    useUpdateEffect
+  );
 
   return previousRef.current;
 }

--- a/src/usePreviousDistinct/usePreviousDistinct.ts
+++ b/src/usePreviousDistinct/usePreviousDistinct.ts
@@ -1,7 +1,6 @@
-import { useRef } from 'react';
-import { useCustomCompareEffect, useUpdateEffect } from '..';
+import { useRef, useState } from 'react';
+import { useUpdateEffect } from '..';
 import { isStrictEqual } from '../util/const';
-import { basicDepsComparator } from '../util/misc';
 
 export type TPredicate = <T>(prev: T, next: any) => next is typeof prev;
 
@@ -20,20 +19,15 @@ export function usePreviousDistinct<T>(
   value: T,
   predicate: TPredicate = isStrictEqual
 ): T | undefined {
-  const previousRef = useRef<T>();
+  const [previousState, setPreviousState] = useState<T>();
   const currentRef = useRef<T>(value);
 
-  useCustomCompareEffect(
-    () => {
-      if (!predicate(currentRef.current, value)) {
-        previousRef.current = currentRef.current;
-        currentRef.current = value;
-      }
-    },
-    [value],
-    basicDepsComparator,
-    useUpdateEffect
-  );
+  useUpdateEffect(() => {
+    if (!predicate(currentRef.current, value)) {
+      setPreviousState(currentRef.current);
+      currentRef.current = value;
+    }
+  }, [value]);
 
-  return previousRef.current;
+  return previousState;
 }

--- a/src/usePreviousDistinct/usePreviousDistinct.ts
+++ b/src/usePreviousDistinct/usePreviousDistinct.ts
@@ -1,0 +1,31 @@
+import { useRef } from 'react';
+import { useFirstMountState } from '..';
+
+export type Predicate<T> = (prev: T | undefined, next: T) => boolean;
+
+const checkIfStrictlyEqual = <T>(prev: T | undefined, next: T) => prev === next;
+
+/**
+ * Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here
+ * means that the hook's return value will only update when the passed value updates. This is
+ * useful when other renders are involved potentially making multiple, irrelavant updates.
+ *
+ * Yields `undefined` on first render.
+ *
+ * @param value Value to yield on next render
+ */
+export function usePreviousDistinct<T>(
+  value: T,
+  compare: Predicate<T> = checkIfStrictlyEqual
+): T | undefined {
+  const previousRef = useRef<T>();
+  const currentRef = useRef<T>(value);
+  const isFirstMount = useFirstMountState();
+
+  if (!isFirstMount && !compare(currentRef.current, value)) {
+    previousRef.current = currentRef.current;
+    currentRef.current = value;
+  }
+
+  return previousRef.current;
+}

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -7,6 +7,10 @@ export const isBrowser =
   typeof navigator !== 'undefined' &&
   typeof document !== 'undefined';
 
+/**
+ * You should only be reaching for this function when you're attempting to prevent multiple
+ * redefinitions of the same function. In-place strict equality checks are more performant.
+ */
 export const isStrictEqual: TPredicate = <T>(prev: T, next: any) => prev === next;
 
 export const truthyAndArrayPredicate: IConditionsPredicate = (conditions): boolean =>

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,4 +1,4 @@
-import { IConditionsPredicate } from '..';
+import { IConditionsPredicate, TPredicate } from '..';
 
 export const noop = (): void => {};
 
@@ -6,6 +6,9 @@ export const isBrowser =
   typeof window !== 'undefined' &&
   typeof navigator !== 'undefined' &&
   typeof document !== 'undefined';
+
+export const isStrictEqual: TPredicate = <T>(prev: T, next: any): next is typeof prev =>
+  prev === next;
 
 export const truthyAndArrayPredicate: IConditionsPredicate = (conditions): boolean =>
   conditions.every((i) => Boolean(i));

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -7,8 +7,7 @@ export const isBrowser =
   typeof navigator !== 'undefined' &&
   typeof document !== 'undefined';
 
-export const isStrictEqual: TPredicate = <T>(prev: T, next: any): next is typeof prev =>
-  prev === next;
+export const isStrictEqual: TPredicate = <T>(prev: T, next: any) => prev === next;
 
 export const truthyAndArrayPredicate: IConditionsPredicate = (conditions): boolean =>
   conditions.every((i) => Boolean(i));

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,4 +1,4 @@
-import { IConditionsPredicate, TPredicate } from '..';
+import { IConditionsPredicate, Predicate } from '..';
 
 export const noop = (): void => {};
 
@@ -11,7 +11,7 @@ export const isBrowser =
  * You should only be reaching for this function when you're attempting to prevent multiple
  * redefinitions of the same function. In-place strict equality checks are more performant.
  */
-export const isStrictEqual: TPredicate = <T>(prev: T, next: any) => prev === next;
+export const isStrictEqual: Predicate = (prev: any, next: any): boolean => prev === next;
 
 export const truthyAndArrayPredicate: IConditionsPredicate = (conditions): boolean =>
   conditions.every((i) => Boolean(i));


### PR DESCRIPTION
## What new hook does?

Outlined in #33 and [here](https://github.com/streamich/react-use/blob/master/docs/usePreviousDistinct.md).

While I haven't needed this hook myself, I began understanding the value and differences `usePrevious` and `usePreviousDistinct` offer. I feel like people who reach for `usePrevious` may wish to know that `usePreviousDistinct` exists. I may not have done well on that front, but wanted to give it a go.

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Does the code have comments in hard-to-understand areas?
- [X] Is there an existing issue for this PR?
  - #33
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated?
- [X] Have the tests been added to cover new hook?
- [X] Have you run the tests locally to confirm they pass?
