### PR TITLE
docs: fix broken link for useNetworkState

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Coming from `react-use`? Check out our
 
 - #### Navigator
 
-  - [**`useNetworkState`**](https://react-hookz.github.io/web/?path=/docs/navigator-usenetwork--example)
+  - [**`useNetworkState`**](https://react-hookz.github.io/web/?path=/docs/navigator-usenetworkstate--example)
     — Tracks the state of browser's network connection.
   - [**`usePermission`**](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission--example)
     — Tracks a permission state.


### PR DESCRIPTION
## What is the problem?
Link for useNetworkState in README is broken

## What changes does this PR make to fix the problem?
Changed it with the correct one

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
