### PR TITLE
feat(`useMediaQuery`): add synchronous mql state fetch

### DIFF
--- a/src/useMediaQuery/__docs__/story.mdx
+++ b/src/useMediaQuery/__docs__/story.mdx
@@ -22,7 +22,7 @@ Tracks the state of CSS media query.
 ## Reference
 
 ```ts
-export function useMediaQuery(query: string): boolean | undefined;
+export function useMediaQuery(query: string, matchOnMount?: boolean): boolean | undefined;
 ```
 
 #### Importing
@@ -32,7 +32,10 @@ export function useMediaQuery(query: string): boolean | undefined;
 #### Arguments
 
 - **query** _`string`_ - CSS media query to track.
+- **matchOnMount** _`boolean`_ - whether hook state should be fetched during effects stage instead
+  of synchronous fetch. _Set this parameter to `true` for SSR use-cases._
 
 #### Return
 
 `boolean` - `true` in case document matches media query, `false` otherwise.
+`undefined` - in case `matchOnMount` parameter set to `true` and effect stage is not done yet.

--- a/src/useMediaQuery/__tests__/dom.ts
+++ b/src/useMediaQuery/__tests__/dom.ts
@@ -56,7 +56,15 @@ describe('useMediaQuery', () => {
 
   it('should return undefined on first render', () => {
     const { result } = renderHook(() => useMediaQuery('max-width : 768px'));
+    expect(result.all.length).toBe(1);
+    expect(result.current).toBe(false);
+  });
+
+  it('should return undefined on first render and `matchOnMount` set to false', () => {
+    const { result } = renderHook(() => useMediaQuery('max-width : 768px', true));
     expect(result.all[0]).toBeUndefined();
+    expect(result.all.length).toBe(2);
+    expect(result.current).toBe(false);
   });
 
   it('should return match state', () => {

--- a/src/useMediaQuery/useMediaQuery.ts
+++ b/src/useMediaQuery/useMediaQuery.ts
@@ -1,21 +1,22 @@
-import { Dispatch, useEffect } from 'react';
-import { useSafeState } from '..';
+import { Dispatch, useCallback, useEffect, useRef } from 'react';
+import { usePrevious, useRerender } from '..';
+import { isBrowser } from '../util/const';
 
 const queriesMap = new Map<
   string,
   { mql: MediaQueryList; dispatchers: Set<Dispatch<boolean>>; listener: () => void }
 >();
 
-const querySubscribe = (query: string, dispatch: Dispatch<boolean>) => {
+type QueryStateSetter = (matches: boolean, initial?: boolean) => void;
+
+const querySubscribe = (query: string, setState: QueryStateSetter) => {
   let entry = queriesMap.get(query);
 
   if (!entry) {
     const mql = matchMedia(query);
-    const dispatchers = new Set<Dispatch<boolean>>();
+    const dispatchers = new Set<QueryStateSetter>();
     const listener = () => {
-      dispatchers.forEach((d) => {
-        d(mql.matches);
-      });
+      dispatchers.forEach((d) => d(mql.matches));
     };
 
     if (mql.addEventListener) mql.addEventListener('change', listener, { passive: true });
@@ -29,18 +30,18 @@ const querySubscribe = (query: string, dispatch: Dispatch<boolean>) => {
     queriesMap.set(query, entry);
   }
 
-  entry.dispatchers.add(dispatch);
-  dispatch(entry.mql.matches);
+  entry.dispatchers.add(setState);
+  setState(entry.mql.matches, true);
 };
 
-const queryUnsubscribe = (query: string, dispatch: Dispatch<boolean>): void => {
+const queryUnsubscribe = (query: string, setState: QueryStateSetter): void => {
   const entry = queriesMap.get(query);
 
   // else path is impossible to test in normal situation
   /* istanbul ignore else */
   if (entry) {
     const { mql, dispatchers, listener } = entry;
-    dispatchers.delete(dispatch);
+    dispatchers.delete(setState);
 
     if (!dispatchers.size) {
       queriesMap.delete(query);
@@ -51,22 +52,50 @@ const queryUnsubscribe = (query: string, dispatch: Dispatch<boolean>): void => {
   }
 };
 
+export function useMediaQuery(query: string, matchOnMount?: false): boolean;
+export function useMediaQuery(query: string, matchOnMount: true): boolean | undefined;
+
 /**
  * Tracks the state of CSS media query.
  *
+ * Defaults to false in SSR environments
+ *
  * @param query CSS media query to track.
+ * @param matchOnMount whether hook state should be fetched during effects stage instead of
+ * synchronous fetch. Set this parameter to `true` for SSR use-cases.
  */
-export function useMediaQuery(query: string): boolean | undefined {
-  const [state, setState] = useSafeState<boolean>();
+export function useMediaQuery(query: string, matchOnMount?: boolean): boolean | undefined {
+  const rerender = useRerender();
+  const previousQuery = usePrevious(query);
 
-  useEffect(() => {
+  const state = useRef<boolean | undefined>();
+
+  const setState = useCallback(
+    (matches: boolean, initial?: boolean) => {
+      if (state.current !== matches) {
+        state.current = matches;
+
+        if (!initial || matchOnMount) rerender();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [matchOnMount]
+  );
+
+  // do synchronous subscription only for case we are in browser and mount match required
+  if (!matchOnMount && isBrowser && previousQuery !== query) {
     querySubscribe(query, setState);
+  }
 
-    return () => {
-      queryUnsubscribe(query, setState);
-    };
+  // otherwise, match should happen in effect stage
+  useEffect(() => {
+    if (matchOnMount) {
+      querySubscribe(query, setState);
+    }
+
+    return () => queryUnsubscribe(query, setState);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
-  return state;
+  return state.current;
 }


### PR DESCRIPTION
BREAKING CHANGE: `useMediaQuery` now does synchronous fetch, this means
that in browser it will return final state on first render, while SSR
mode still return `undefined`.
SSR users should set second parameter of this hook to `true`, to
postpone state fetch until effects phase.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
