### PR TITLE
feat: create `useRafEffect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn add @react-hookz/web
 ```
 
 As hooks was introduced to the world in React 16.8, `@react-hookz/web` requires - you guessed it -
-`react` and `react-dom` 16.8+.  
+`react` and `react-dom` 16.8+.
 Also, as React does not support IE, `@react-hookz/web` does not do so either. You'll have to
 transpile your `node-modules` in order to run in IE.
 
@@ -90,6 +90,8 @@ Coming from `react-use`? Check out our
     — `useLayoutEffect` for browser with fallback to `useEffect` for SSR.
   - [**`useMountEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemounteffect--example)
     — Run effect only when component first-mounted.
+  - [**`useRafEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRafEffect--example)
+    — Like `React.useEffect`, but effect is only run within animation frame.
   - [**`useRerender`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usererender--example)
     — Return callback that re-renders component.
   - [**`useThrottledEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usethrottledeffect--example)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { useFirstMountState } from './useFirstMountState/useFirstMountState';
 export { useIsMounted } from './useIsMounted/useIsMounted';
 export { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect/useIsomorphicLayoutEffect';
 export { useMountEffect } from './useMountEffect/useMountEffect';
+export { useRafEffect } from './useRafEffect/useRafEffect';
 export { useRerender } from './useRerender/useRerender';
 export { useThrottledEffect } from './useThrottledEffect/useThrottledEffect';
 export { useUnmountEffect } from './useUnmountEffect/useUnmountEffect';

--- a/src/useRafEffect/__docs__/example.stories.tsx
+++ b/src/useRafEffect/__docs__/example.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { useRef } from 'react';
+import { useRafEffect } from '../..';
+
+export const Example: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useRafEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef.current]);
+
+  return (
+    <div>
+      The focus will be set on the input element below after the first animation frame. This is
+      helpful if your input is, for example, in a portal and you encouter issues interacting with
+      the DOM before the first animation frame.{' '}
+      <a target="_blank" href="https://github.com/reactjs/reactjs.org/issues/272" rel="noreferrer">
+        See this issue
+      </a>
+      .
+      <div>
+        <input ref={inputRef} />
+      </div>
+    </div>
+  );
+};

--- a/src/useRafEffect/__docs__/story.mdx
+++ b/src/useRafEffect/__docs__/story.mdx
@@ -1,0 +1,34 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
+
+<Meta title="Lifecycle/useRafEffect" component={Example} />
+
+# useRafEffect
+
+Like `React.useEffect`, but effect is only run within animation frame.
+
+- Auto-cancel animation frame on component unmount.
+- SSR-friendly.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+export function useRafEffect(callback: (...args: any[]) => void, deps: DependencyList): void;
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+- **callback** _`(...args: any[]) => void`_ - Callback like for `useEffect`, but without ability to
+  return a cleanup function.
+- **deps** _`DependencyList`_ - Dependencies list that will be passed to underlying `useEffect`.

--- a/src/useRafEffect/__tests__/dom.ts
+++ b/src/useRafEffect/__tests__/dom.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react-hooks/dom';
+import { useRafEffect } from '../..';
+
+describe('useRafEffect', () => {
+  const raf = global.requestAnimationFrame;
+  const caf = global.cancelAnimationFrame;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+
+    global.requestAnimationFrame = (cb) => setTimeout(cb);
+    global.cancelAnimationFrame = (cb) => clearTimeout(cb);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+
+    global.requestAnimationFrame = raf;
+    global.cancelAnimationFrame = caf;
+  });
+
+  it('should be defined', () => {
+    expect(useRafEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useRafEffect(() => {}, []));
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should not run unless animation frame', () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook((dep) => useRafEffect(spy, [dep]), {
+      initialProps: 1,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender(2);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      jest.advanceTimersToNextTimer();
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cancel animation frame on unmount', () => {
+    const spy = jest.fn();
+    const { rerender, unmount } = renderHook((dep) => useRafEffect(spy, [dep]), {
+      initialProps: 1,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    rerender(2);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    unmount();
+
+    act(() => {
+      jest.advanceTimersToNextTimer();
+    });
+
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/useRafEffect/__tests__/ssr.ts
+++ b/src/useRafEffect/__tests__/ssr.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useRafEffect } from '../..';
+
+describe('useRafEffect', () => {
+  it('should be defined', () => {
+    expect(useRafEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useRafEffect(() => {}, []));
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/useRafEffect/useRafEffect.ts
+++ b/src/useRafEffect/useRafEffect.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DependencyList, useEffect } from 'react';
+import { useRafCallback } from '..';
+
+/**
+ * Like `React.useEffect`, but state is only updated within animation frame.
+ *
+ * @param callback Callback like for `useEffect`, but without ability to return
+ * a cleanup function.
+ * @param deps Dependencies list that will be passed to underlying `useEffect`.
+ */
+export function useRafEffect(callback: (...args: any[]) => void, deps: DependencyList): void {
+  const [rafCallback, cancelRaf] = useRafCallback(callback);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(
+    () => {
+      rafCallback();
+
+      return cancelRaf;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps
+  );
+}


### PR DESCRIPTION
## What new hook does?

Like `React.useEffect`, but effect is only run within animation frame.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  -https://github.com/react-hookz/web/issues/33
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
