### PR TITLE
fix: make `useRerender` operate integer increment instead of bool switch

### DIFF
--- a/src/useRerender/__tests__/dom.ts
+++ b/src/useRerender/__tests__/dom.ts
@@ -29,10 +29,12 @@ describe('useRerender', () => {
     });
 
     expect(result.current[1]).toBe(1);
+
     act(() => {
       result.current[0]();
     });
     expect(result.current[1]).toBe(2);
+
     act(() => {
       result.current[0]();
     });

--- a/src/useRerender/__tests__/dom.ts
+++ b/src/useRerender/__tests__/dom.ts
@@ -31,11 +31,15 @@ describe('useRerender', () => {
     expect(result.current[1]).toBe(1);
 
     act(() => {
+      // https://github.com/react-hookz/web/issues/691
+      result.current[0]();
       result.current[0]();
     });
     expect(result.current[1]).toBe(2);
 
     act(() => {
+      result.current[0]();
+      result.current[0]();
       result.current[0]();
     });
     expect(result.current[1]).toBe(3);

--- a/src/useRerender/useRerender.ts
+++ b/src/useRerender/useRerender.ts
@@ -1,13 +1,13 @@
 import { useCallback } from 'react';
 import { useSafeState } from '..';
 
-const stateChanger = (state: boolean) => !state;
+const stateChanger = (state: number) => state + (1 % Number.MAX_SAFE_INTEGER);
 
 /**
  * Return callback function that re-renders component.
  */
 export function useRerender(): () => void {
-  const [, setState] = useSafeState(false);
+  const [, setState] = useSafeState(0);
 
   return useCallback(() => {
     setState(stateChanger);


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?
Even amount of `useRerender` calls causes no rerender.

### What is the expected behavior?
`useRerender` should cause rereder in any case

### How does this PR fix the problem?
Replace boolean switch with integer incrementation. Also it is guarded from overflow.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #691
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
