### PR TITLE
feat(useCounter): port `useCounter` from `react-use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Coming from `react-use`? Check out our
 
 - #### State
 
+  - [**`useCounter`**](https://react-hookz.github.io/web/?path=/docs/state-usecounter--example)
+    - Tracks a numeric value and offers functions for manipulating it.
   - [**`useDebouncedState`**](https://react-hookz.github.io/web/?path=/docs/state-usedebouncedstate--example)
     — Like `useSafeState` but its state setter is debounced.
   - [**`useMap`**](https://react-hookz.github.io/web/?path=/docs/state-usemap--example) — Tracks the

--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -650,11 +650,11 @@ Use [useToggle](/docs/state-usetoggle--example) instead
 
 #### useCounter
 
-Not implemented yet
+Implemented as [useCounter](/docs/state-usecounter--example)
 
 #### useNumber
 
-Not implemented yet
+Use [useCounter](/docs/state-usecounter--example) instead.
 
 #### useList
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   IValidityState,
   IUseValidatorReturn,
 } from './useValidator/useValidator';
+export { useCounter, CounterActions } from './useCounter/useCounter';
 
 // Navigator
 export {

--- a/src/useCounter/__docs__/example.stories.tsx
+++ b/src/useCounter/__docs__/example.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useCounter } from '../..';
+
+export const Example: React.FC = () => {
+  const [min, { inc: incMin, dec: decMin }] = useCounter(1);
+  const [max, { inc: incMax, dec: decMax }] = useCounter(10);
+  const [value, { inc, dec, set, reset }] = useCounter(5, max, min);
+
+  return (
+    <div>
+      <div>
+        current: {value} [min: {min}; max: {max}]
+      </div>
+      <br />
+      Current value:
+      <button onClick={() => inc()}>Increment</button>
+      <button onClick={() => dec()}>Decrement</button>
+      <button onClick={() => inc(5)}>Increment (+5)</button>
+      <button onClick={() => dec(5)}>Decrement (-5)</button>
+      <button onClick={() => set(100)}>Set 100</button>
+      <button onClick={() => reset()}>Reset</button>
+      <button onClick={() => reset(25)}>Reset (25)</button>
+      <br />
+      <br />
+      Min value:
+      <button onClick={() => incMin()}>Increment</button>
+      <button onClick={() => decMin()}>Decrement</button>
+      <br />
+      <br />
+      Max value:
+      <button onClick={() => incMax()}>Increment</button>
+      <button onClick={() => decMax()}>Decrement</button>
+    </div>
+  );
+};

--- a/src/useCounter/__docs__/story.mdx
+++ b/src/useCounter/__docs__/story.mdx
@@ -1,0 +1,55 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
+
+<Meta title="State/useCounter" component={Example} />
+
+# useCounter
+
+Tracks a numeric value and offers functions for manipulating it.
+
+> **_This hook provides stable API, meaning returned functions do not change between renders_**
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+export function useCounter(
+  initialValue: IInitialState<number> = 0,
+  max?: number,
+  min?: number
+): [number, CounterActions];
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+- _**initialValue**_ _`IInitialState<number>` (default 0)_ - initial value for the counter. A number
+  or function returning a number.
+- _**max**_ _`number` (default `undefined`)_ - maximum value the counter is allowed to be set.
+- _**min**_ _`number` (default `undefined`)_ - minimum value the counter is allowed to be set.
+
+#### Return
+
+1. **counter** - The current value of the counter.
+
+2. **methods**
+
+   - **get** - Returns the current value of the counter.
+   - **inc** - Increments the counter by the given delta (by default, 1).
+   - **dec** - Decrements the counter by the given delta (by default, 1).
+   - **set** - Sets the counter to the given value.
+   - **reset** - Resets the counter to its initial value. If a value is given, it
+     is set as the new initial value and any future calls to `reset`
+     without arguments will reset the counter to the given value.
+
+   All methods respect the `max` and `min` parameters. Instead of numerical
+   arguments, they also accept functions returning numbers.

--- a/src/useCounter/__tests__/dom.ts
+++ b/src/useCounter/__tests__/dom.ts
@@ -1,0 +1,232 @@
+import { act, renderHook } from '@testing-library/react-hooks/dom';
+import { useCounter } from '../..';
+
+describe('useCounter', () => {
+  it('should be defined', () => {
+    expect(useCounter).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useCounter());
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should have default initial value of 0', () => {
+    const { result } = renderHook(() => useCounter());
+    const counter = result.current[0];
+    expect(counter).toEqual(0);
+  });
+
+  it('should accept custom initial value', () => {
+    const { result } = renderHook(() => useCounter(5));
+    const counter = result.current[0];
+    expect(counter).toEqual(5);
+  });
+
+  it('should accept function returning a number as initial value', () => {
+    const { result } = renderHook(() => useCounter(() => 5));
+    const counter = result.current[0];
+    expect(counter).toEqual(5);
+  });
+
+  it('should force initial value to be at least the given minimum value', () => {
+    const { result } = renderHook(() => useCounter(0, 10, 5));
+    const counter = result.current[0];
+    expect(counter).toEqual(5);
+  });
+
+  it('should force initial value to be at most the given maximum value', () => {
+    const { result } = renderHook(() => useCounter(10, 5));
+    const counter = result.current[0];
+    expect(counter).toEqual(5);
+  });
+
+  it('get returns the current counter value', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { get } = result.current[1];
+
+    act(() => {
+      expect(get()).toEqual(result.current[0]);
+    });
+  });
+
+  it('set sets the counter to any value', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { set } = result.current[1];
+
+    act(() => {
+      set(2);
+    });
+
+    expect(result.current[0]).toEqual(2);
+
+    act(() => {
+      set((current: number) => current + 5);
+    });
+
+    expect(result.current[0]).toEqual(7);
+
+    act(() => {
+      set(12);
+    });
+
+    expect(result.current[0]).toEqual(12);
+  });
+
+  it('set respects min and max parameters', () => {
+    const { result } = renderHook(() => useCounter(0, 10, 0));
+    const { set } = result.current[1];
+
+    act(() => {
+      set(-2);
+    });
+
+    expect(result.current[0]).toEqual(0);
+
+    act(() => {
+      set(12);
+    });
+
+    expect(result.current[0]).toEqual(10);
+  });
+
+  it('inc increments the counter by 1 if no delta given', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { inc } = result.current[1];
+
+    act(() => {
+      inc();
+    });
+
+    const counter = result.current[0];
+    expect(counter).toEqual(1);
+  });
+
+  it('inc increments the counter by the given delta', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { inc } = result.current[1];
+
+    act(() => {
+      inc(2);
+    });
+
+    expect(result.current[0]).toEqual(2);
+
+    act(() => {
+      inc((current) => current + 1);
+    });
+
+    expect(result.current[0]).toEqual(5);
+  });
+
+  it('inc respects min and max parameters', () => {
+    const { result } = renderHook(() => useCounter(0, 5, 0));
+    const { inc } = result.current[1];
+
+    act(() => {
+      inc(-2);
+    });
+
+    expect(result.current[0]).toEqual(0);
+
+    act(() => {
+      inc(12);
+    });
+
+    expect(result.current[0]).toEqual(5);
+  });
+
+  it('dec decrements the counter by 1 if no delta given', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { dec } = result.current[1];
+
+    act(() => {
+      dec();
+    });
+
+    const counter = result.current[0];
+    expect(counter).toEqual(-1);
+  });
+
+  it('dec decrements the counter by the given delta', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { dec } = result.current[1];
+
+    act(() => {
+      dec(2);
+    });
+
+    expect(result.current[0]).toEqual(-2);
+
+    act(() => {
+      dec((current) => current + 1);
+    });
+
+    expect(result.current[0]).toEqual(-1);
+  });
+
+  it('dec respects min and max parameters', () => {
+    const { result } = renderHook(() => useCounter(0, 5, 0));
+    const { dec } = result.current[1];
+
+    act(() => {
+      dec(2);
+    });
+
+    expect(result.current[0]).toEqual(0);
+
+    act(() => {
+      dec(-12);
+    });
+
+    expect(result.current[0]).toEqual(5);
+  });
+
+  it('reset without arguments sets the counter to its initial value', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { reset, inc } = result.current[1];
+
+    act(() => {
+      inc();
+      reset();
+    });
+
+    expect(result.current[0]).toEqual(0);
+  });
+
+  it('reset with argument sets the counter to its new initial value', () => {
+    const { result } = renderHook(() => useCounter(0));
+    const { reset, inc } = result.current[1];
+
+    act(() => {
+      inc();
+      reset(5);
+    });
+
+    expect(result.current[0]).toEqual(5);
+
+    act(() => {
+      inc();
+      reset();
+    });
+
+    expect(result.current[0]).toEqual(5);
+  });
+
+  it('reset respects min and max parameters', () => {
+    const { result } = renderHook(() => useCounter(0, 10, 0));
+    const { reset } = result.current[1];
+
+    act(() => {
+      reset(25);
+    });
+
+    expect(result.current[0]).toEqual(10);
+
+    act(() => {
+      reset(-10);
+    });
+
+    expect(result.current[0]).toEqual(0);
+  });
+});

--- a/src/useCounter/__tests__/dom.ts
+++ b/src/useCounter/__tests__/dom.ts
@@ -210,7 +210,7 @@ describe('useCounter', () => {
       reset();
     });
 
-    expect(result.current[0]).toEqual(5);
+    expect(result.current[0]).toEqual(0);
   });
 
   it('reset respects min and max parameters', () => {

--- a/src/useCounter/__tests__/ssr.ts
+++ b/src/useCounter/__tests__/ssr.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useCounter } from '../..';
+
+describe('useCounter', () => {
+  it('should be defined', () => {
+    expect(useCounter).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useCounter());
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/useCounter/useCounter.ts
+++ b/src/useCounter/useCounter.ts
@@ -50,7 +50,7 @@ export function useCounter(
   max?: number,
   min?: number
 ): [number, CounterActions] {
-  const mediator = (v: number): number => {
+  const [state, setState] = useMediatedState(initialValue, (v: number): number => {
     if (typeof max !== 'undefined') {
       v = Math.min(max, v);
     }
@@ -60,12 +60,7 @@ export function useCounter(
     }
 
     return v;
-  };
-
-  const [state, setState] = useMediatedState(
-    () => mediator(resolveHookState(initialValue)),
-    mediator
-  );
+  });
   const stateRef = useSyncedRef(state);
 
   return [
@@ -84,7 +79,7 @@ export function useCounter(
           setState((v) => resolveHookState(val, v));
         },
       }),
-      []
+      [initialValue, setState, stateRef]
     ),
   ];
 }

--- a/src/useCounter/useCounter.ts
+++ b/src/useCounter/useCounter.ts
@@ -1,0 +1,116 @@
+import { SetStateAction, useCallback, useRef } from 'react';
+import { IInitialState, resolveHookState } from '../util/resolveHookState';
+import { useSafeState, useSyncedRef } from '..';
+
+export interface CounterActions {
+  /**
+   * Returns the current value of the counter.
+   */
+  get: () => number;
+  /**
+   * Increment the counter by the given `delta`.
+   *
+   * @param `delta` number or function returning a number. By default, `delta` is 1.
+   */
+  inc: (delta?: SetStateAction<number>) => void;
+  /**
+   * Decrement the counter by the given `delta`.
+   *
+   * @param `delta` number or function returning a number. By default, `delta` is 1.
+   */
+  dec: (delta?: SetStateAction<number>) => void;
+  /**
+   * Set the counter to any value, limited only by the `min` and `max` parameters of the hook.
+   *
+   * @param `value` number or function returning a number
+   */
+  set: (value: SetStateAction<number>) => void;
+  /**
+   * Resets the counter to its original initial value.
+   *
+   * If `value` is given, then it becomes the new initial value of the hook and
+   * following calls to `reset` without arguments will reset the counter to `value`.
+   *
+   * @param `value` number or function returning a number
+   */
+  reset: (value?: SetStateAction<number>) => void;
+}
+
+/**
+ * Tracks a numeric value.
+ *
+ * @param initialValue The initial value of the counter.
+ * @param max The maximum value the counter is allowed to reach.
+ *            If `initialValue` is greater than `max`, then `max` is set as the initial value.
+ * @param min The minimum value the counter is allowed to reach.
+ *            If `initialValue` is smaller than `min`, then `min` is set as the initial value.
+ */
+export function useCounter(
+  initialValue: IInitialState<number> = 0,
+  max?: number,
+  min?: number
+): [number, CounterActions] {
+  const resolvedInitialValue = resolveHookState(initialValue);
+
+  const fitInRange = useCallback(
+    (value: number) => {
+      let fittedValue = value;
+
+      if (typeof max !== 'undefined') {
+        fittedValue = Math.min(max, fittedValue);
+      }
+
+      if (typeof min !== 'undefined') {
+        fittedValue = Math.max(min, fittedValue);
+      }
+
+      return fittedValue;
+    },
+    [max, min]
+  );
+
+  const init = useRef(fitInRange(resolvedInitialValue));
+
+  const [counter, setCounter] = useSafeState(init.current);
+  const counterRef = useSyncedRef(counter);
+
+  const get = useCallback(() => counterRef.current, [counterRef]);
+
+  const set = useCallback(
+    (value: SetStateAction<number>) => {
+      const resolvedValue = resolveHookState(value, counterRef.current);
+      setCounter(fitInRange(resolvedValue));
+    },
+    [counterRef, fitInRange, setCounter]
+  );
+
+  const inc = useCallback(
+    (delta: SetStateAction<number> = 1) => {
+      const resolvedDelta = resolveHookState(delta, counterRef.current);
+      set((prevState) => prevState + resolvedDelta);
+    },
+    [counterRef, set]
+  );
+
+  const dec = useCallback(
+    (delta: SetStateAction<number> = 1) => {
+      const resolvedDelta = resolveHookState(delta, counterRef.current);
+      set((prevState) => prevState - resolvedDelta);
+    },
+    [counterRef, set]
+  );
+
+  const reset = useCallback(
+    (value: SetStateAction<number> = init.current) => {
+      const resolvedValue = resolveHookState(value, counterRef.current);
+      const fittedResolvedValue = fitInRange(resolvedValue);
+      init.current = fittedResolvedValue;
+      set(fittedResolvedValue);
+    },
+    [counterRef, fitInRange, set]
+  );
+
+  const counterActions: CounterActions = { get, inc, dec, set, reset };
+
+  return [counter, counterActions];
+}


### PR DESCRIPTION
## What new hook does?
This hook tracks a numeric value and offers functions for manipulating it.

The exact same API from `react-use` is retained.

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Does the code have comments in hard-to-understand areas?
- [X] Is there an existing issue for this PR?
  - #33 
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated?
- [X] Have the tests been added to cover new hook?
- [X] Have you run the tests locally to confirm they pass?
