### PR TITLE
fix: `useUnmountEffect` now invokes changing effect functions

### DIFF
--- a/src/useUnmountEffect/__tests__/dom.ts
+++ b/src/useUnmountEffect/__tests__/dom.ts
@@ -11,14 +11,23 @@ describe('useUnmountEffect', () => {
     expect(spy).toHaveBeenCalledTimes(0);
 
     rerender();
-    rerender();
-    rerender();
-    rerender();
-
-    expect(spy).toHaveBeenCalledTimes(0);
-
     unmount();
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call effect even if it has been updated', () => {
+    const spy = jest.fn();
+
+    const { rerender, unmount } = renderHook(({ fn }) => useUnmountEffect(fn), {
+      initialProps: {
+        fn: () => {},
+      },
+    });
+
+    rerender({ fn: spy });
+    unmount();
+
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/useUnmountEffect/useUnmountEffect.ts
+++ b/src/useUnmountEffect/useUnmountEffect.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 /**
  * Run effect only when component is unmounted.
@@ -6,9 +7,11 @@ import { useEffect } from 'react';
  * @param effect Effector to run on unmount
  */
 export function useUnmountEffect(effect: CallableFunction): void {
+  const effectRef = useSyncedRef(effect);
+
   useEffect(
     () => () => {
-      effect();
+      effectRef.current();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []


### PR DESCRIPTION
fix #756

### How does this PR fix the problem?

Use `useSyncedRef` to handle effector changes.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #756 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
