### PR TITLE
fix: `useResizeObserver` now respects element changes within ref object

### DIFF
--- a/src/useMeasure/useMeasure.ts
+++ b/src/useMeasure/useMeasure.ts
@@ -1,5 +1,5 @@
-import { RefObject, useRef } from 'react';
-import { useSafeState, IUseResizeObserverCallback, useResizeObserver, useRafCallback } from '..';
+import { MutableRefObject, useRef } from 'react';
+import { IUseResizeObserverCallback, useRafCallback, useResizeObserver, useSafeState } from '..';
 
 /**
  * Uses ResizeObserver to track element dimensions and re-render component when they change.
@@ -8,8 +8,8 @@ import { useSafeState, IUseResizeObserverCallback, useResizeObserver, useRafCall
  */
 export function useMeasure<T extends Element>(
   enabled = true
-): [DOMRectReadOnly | undefined, RefObject<T>] {
-  const elementRef = useRef<T>(null);
+): [DOMRectReadOnly | undefined, MutableRefObject<T | null>] {
+  const elementRef = useRef<T | null>(null);
   const [rect, setRect] = useSafeState<DOMRectReadOnly>();
   const [observerHandler] = useRafCallback<IUseResizeObserverCallback>((entry) =>
     setRect(entry.contentRect)

--- a/src/useResizeObserver/__tests__/dom.ts
+++ b/src/useResizeObserver/__tests__/dom.ts
@@ -51,6 +51,39 @@ describe('useResizeObserver', () => {
     expect(ResizeObserverSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('should subscribe in case ref first was empty but then gained element', () => {
+    const div = document.createElement('div');
+    const ref: React.MutableRefObject<Element | null> = { current: null };
+    const spy = jest.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    const { rerender } = renderHook(({ ref }) => useResizeObserver(ref, spy), {
+      initialProps: { ref },
+    });
+
+    expect(observeSpy).toHaveBeenCalledTimes(0);
+
+    ref.current = div;
+    rerender({ ref });
+
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+
+    const entry = {
+      target: div,
+      contentRect: {},
+      borderBoxSize: {},
+      contentBoxSize: {},
+    } as unknown as ResizeObserverEntry;
+
+    ResizeObserverSpy.mock.calls[0][0]([entry]);
+
+    expect(spy).not.toHaveBeenCalledWith(entry);
+
+    jest.advanceTimersByTime(1);
+
+    expect(spy).toHaveBeenCalledWith(entry);
+  });
+
   it('should invoke each callback listening same element asynchronously using setTimeout0', () => {
     const div = document.createElement('div');
     const spy1 = jest.fn();


### PR DESCRIPTION
## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - fix #755
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
