### PR TITLE
fix: Apply correct order of operations in `useRerender`

### DIFF
--- a/src/useRerender/useRerender.ts
+++ b/src/useRerender/useRerender.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useSafeState } from '..';
 
-const stateChanger = (state: number) => state + (1 % Number.MAX_SAFE_INTEGER);
+const stateChanger = (state: number) => (state + 1) % Number.MAX_SAFE_INTEGER;
 
 /**
  * Return callback function that re-renders component.


### PR DESCRIPTION
First add one to state and then get reminder of max safe integer

### What is the current behavior, and the steps to reproduce the issue?

Modulo is never applied

### What is the expected behavior?

Number is always smaller than MAX_SAFE_INTEGER

### How does this PR fix the problem?

It applies correct order of operations 

## Checklist

- [x] Have you read [contribution guideline](https://github.com/react-hookz/web/blob/master/CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
