### PR TITLE
fix(useMediaQuery): fix state stuck for concurrent mode

### DIFF
--- a/src/useMediaQuery/__docs__/example.stories.tsx
+++ b/src/useMediaQuery/__docs__/example.stories.tsx
@@ -17,16 +17,20 @@ export const Example: React.FC = () => {
       <br />
       <br />
       <div>
-        Small device (<code>max-width : 768px</code>): {isSmallDevice ? 'yes' : 'no'}
+        Small device (<code>max-width : 768px</code>):{' '}
+        {isSmallDevice === undefined ? 'unknown' : isSmallDevice ? 'yes' : 'no'}
       </div>
       <div>
-        Medium device (<code>max-width : 992px</code>): {isMediumDevice ? 'yes' : 'no'}
+        Medium device (<code>max-width : 992px</code>):{' '}
+        {isMediumDevice === undefined ? 'unknown' : isMediumDevice ? 'yes' : 'no'}
       </div>
       <div>
-        Large device (<code>max-width : 1200px</code>): {isLargeDevice ? 'yes' : 'no'}
+        Large device (<code>max-width : 1200px</code>):{' '}
+        {isLargeDevice === undefined ? 'unknown' : isLargeDevice ? 'yes' : 'no'}
       </div>
       <div>
-        Extra large device (<code>min-width : 1201px</code>): {isExtraLargeDevice ? 'yes' : 'no'}
+        Extra large device (<code>min-width : 1201px</code>):{' '}
+        {isExtraLargeDevice === undefined ? 'unknown' : isExtraLargeDevice ? 'yes' : 'no'}
       </div>
     </div>
   );

--- a/src/useMediaQuery/__docs__/story.mdx
+++ b/src/useMediaQuery/__docs__/story.mdx
@@ -22,7 +22,7 @@ Tracks the state of CSS media query.
 ## Reference
 
 ```ts
-export function useMediaQuery(query: string, matchOnMount?: boolean): boolean | undefined;
+export function useMediaQuery(query: string): boolean | undefined;
 ```
 
 #### Importing
@@ -32,10 +32,8 @@ export function useMediaQuery(query: string, matchOnMount?: boolean): boolean | 
 #### Arguments
 
 - **query** _`string`_ - CSS media query to track.
-- **matchOnMount** _`boolean`_ - whether hook state should be fetched during effects stage instead
-  of synchronous fetch. _Set this parameter to `true` for SSR use-cases._
 
 #### Return
 
 `boolean` - `true` in case document matches media query, `false` otherwise.
-`undefined` - in case `matchOnMount` parameter set to `true` and effect stage is not done yet.
+`undefined` - initially, when media query isn't matched yet.

--- a/src/useMediaQuery/__tests__/dom.ts
+++ b/src/useMediaQuery/__tests__/dom.ts
@@ -56,14 +56,8 @@ describe('useMediaQuery', () => {
 
   it('should return undefined on first render', () => {
     const { result } = renderHook(() => useMediaQuery('max-width : 768px'));
-    expect(result.all.length).toBe(1);
-    expect(result.current).toBe(false);
-  });
-
-  it('should return undefined on first render and `matchOnMount` set to false', () => {
-    const { result } = renderHook(() => useMediaQuery('max-width : 768px', true));
-    expect(result.all[0]).toBeUndefined();
     expect(result.all.length).toBe(2);
+    expect(result.all[0]).toBe(undefined);
     expect(result.current).toBe(false);
   });
 

--- a/src/useScreenOrientation/useScreenOrientation.ts
+++ b/src/useScreenOrientation/useScreenOrientation.ts
@@ -8,6 +8,8 @@ export type ScreenOrientation = 'portrait' | 'landscape';
  * As `Screen Orientation API` is still experimental and not supported by Safari, this
  * hook uses CSS3 `orientation` media-query to check screen orientation.
  */
-export function useScreenOrientation(): ScreenOrientation {
-  return useMediaQuery('(orientation: portrait)') ? 'portrait' : 'landscape';
+export function useScreenOrientation(): ScreenOrientation | undefined {
+  const matches = useMediaQuery('(orientation: portrait)');
+
+  return typeof matches === 'undefined' ? undefined : matches ? 'portrait' : 'landscape';
 }


### PR DESCRIPTION
In concurrent mode along with strict mode - synchronous mql state fetch 
leads to state stuck. The only way to fix that behaviour is to switch 
back to fully asynchronous code.

Upsides - way simpler code, and reduced amount of it.

Due to changes `useScreenOrientation` also affected.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - fix #849 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
