### PR TITLE
feat: Implement useCopyToClipboard hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Coming from `react-use`? Check out our
     — Provides vibration feedback using the Vibration API.
   - [**`usePermission`**](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission--example)
     — Tracks a permission state.
+  - [**`useCopyToClipboard`**](https://react-hookz.github.io/web/?path=/docs/navigator-usecopytoclipboard--example)
 
 - #### Miscellaneous
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export {
 } from './useValidator/useValidator';
 
 // Navigator
+export { useCopyToClipboard, CopyToClipboardState } from './useCopyToClipboard/useCopyToClipboard';
 export {
   useNetworkState,
   IUseNetworkState,

--- a/src/useCopyToClipboard/__docs__/example.stories.tsx
+++ b/src/useCopyToClipboard/__docs__/example.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useCopyToClipboard } from '../useCopyToClipboard';
+
+export const Example: React.FC = () => {
+  const [value, setValue] = useState('');
+
+  const [copyState, copyToClipboard, resetCopyState] = useCopyToClipboard();
+
+  return (
+    <div>
+      <div style={{ marginBottom: '1em' }}>
+        <label htmlFor="value-to-copy">
+          <div>Enter value to copy</div>
+          <input id="value-to-copy" value={value} onChange={(e) => setValue(e.target.value)} />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5em' }}>
+        <button disabled={value.length === 0} onClick={() => copyToClipboard(value)}>
+          Copy to clipboard
+        </button>
+        <button onClick={() => copyToClipboard(1234 as unknown as string)}>
+          Copy invalid data to clipboard (error)
+        </button>
+        <button onClick={resetCopyState}>Reset copy state</button>
+      </div>
+      <div style={{ marginBottom: '1em' }}>
+        <pre>
+          <code>
+            {JSON.stringify({
+              ...copyState,
+              error: copyState.error ? { message: copyState.error.message } : undefined,
+            })}
+          </code>
+        </pre>
+      </div>
+      {copyState.success ? (
+        <div style={{ color: 'green' }}>Successfully copied to clipboard</div>
+      ) : copyState.success === false ? (
+        <div style={{ color: 'red' }}>
+          Failed to copy to clipboard: {copyState.error?.message ?? 'No error set'}
+        </div>
+      ) : (
+        <div>Not copied to clipboard yet</div>
+      )}
+    </div>
+  );
+};

--- a/src/useCopyToClipboard/__docs__/story.mdx
+++ b/src/useCopyToClipboard/__docs__/story.mdx
@@ -1,0 +1,51 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Example } from './example.stories';
+import { ImportPath } from '../../__docs__/ImportPath';
+
+<Meta title="Navigator/useCopyToClipboard" component={Example} />
+
+# useCopyToClipboard
+
+Copy text to clipboard and provides a state to know if copy was performed or not or if it failed.
+It's based on the Navigator's clipboard API,
+[see on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API).
+
+> This hook uses `useSafeState` underneath, so it is safe to use its `copyToClipboard` and
+> `resetCopyState` callbacks in async hooks.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} />
+</Canvas>
+
+## Reference
+
+```ts
+type CopyToClipboardState =
+  | {
+      value: undefined;
+      success: undefined;
+      error: undefined;
+    }
+  | {
+      value: string;
+      success: true;
+      error?: undefined;
+    }
+  | {
+      success: false;
+      value?: undefined;
+      error: Error;
+    };
+
+export function useCopyToClipboard(): [
+  copyState: CopyToClipboardState,
+  copyToClipboard: (text: string) => void,
+  resetCopyState: () => void
+];
+```
+
+#### Importing
+
+<ImportPath />

--- a/src/useCopyToClipboard/__tests__/dom.ts
+++ b/src/useCopyToClipboard/__tests__/dom.ts
@@ -1,0 +1,198 @@
+import { act, renderHook } from '@testing-library/react-hooks/dom';
+import { useCopyToClipboard } from '../..';
+
+describe('useCopyToClipboard', () => {
+  let mockWriteText: jest.Mock;
+  let warnSpy: jest.SpyInstance;
+  const originalClipboard = {
+    ...global.navigator.clipboard,
+  };
+
+  const mockTextToCopy = 'react-hookz';
+
+  afterAll(() => {
+    Object.assign(navigator, {
+      clipboard: originalClipboard,
+    });
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: () => {},
+      },
+    });
+
+    mockWriteText = jest.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolve();
+        })
+    );
+    jest.spyOn(navigator.clipboard, 'writeText').mockImplementation(mockWriteText);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('should be defined', () => {
+    expect(useCopyToClipboard).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should copy text into clipboard state', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(result.current[0].success).toBeTruthy();
+    expect(result.current[0].value).toEqual(mockTextToCopy);
+  });
+
+  it('should call native API to copy into clipboard', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(mockWriteText).toHaveBeenCalledTimes(1);
+    expect(mockWriteText).toHaveBeenCalledWith(mockTextToCopy);
+  });
+
+  it('should reset copy state when resetState called', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(result.current[0].success).toBeTruthy();
+    expect(result.current[0].value).toEqual(mockTextToCopy);
+
+    await act(() => {
+      result.current[2]();
+      return waitForNextUpdate();
+    });
+
+    expect(result.current[0].success).toBeUndefined();
+    expect(result.current[0].value).toBeUndefined();
+    expect(result.current[0].error).toBeUndefined();
+  });
+
+  it('should set error when clipboard API not supported', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+    Object.assign(global.navigator, {
+      clipboard: undefined,
+    });
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(mockWriteText).not.toHaveBeenCalled();
+    expect(result.current[0].error).toEqual(
+      new Error('Clipboard API not supported by the browser')
+    );
+    expect(result.current[0].success).toEqual(false);
+  });
+
+  it.each([null, undefined, 9, ['a', 'b', 'c'], { a: 0 }])(
+    'should set error when trying to copy %s',
+    async (value) => {
+      const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+
+      await act(() => {
+        result.current[1](value as unknown as string);
+        return waitForNextUpdate();
+      });
+
+      expect(result.current[0].success).toEqual(false);
+      expect(result.current[0].error).toEqual(new Error('Data to copy must be a string'));
+    }
+  );
+
+  it('should set rejection error when proper error', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+    const mockedError = new Error('Unexpected error');
+    const mockWriteTextWithError = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          reject(mockedError);
+        })
+    );
+    jest.spyOn(navigator.clipboard, 'writeText').mockImplementation(mockWriteTextWithError);
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(warnSpy).toBeCalledWith(mockedError);
+    expect(mockWriteTextWithError).toHaveBeenCalledWith(mockTextToCopy);
+    expect(result.current[0].success).toEqual(false);
+    expect(result.current[0].error).toBe(mockedError);
+    expect(result.current[0].value).toBeUndefined();
+  });
+
+  it('should wrap rejection reason in error when string passed as reject param', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+    const mockedErrorMessage = 'Custom unexpected error';
+    const expectedError = new Error(mockedErrorMessage);
+    const mockWriteTextWithError = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          // eslint-disable-next-line prefer-promise-reject-errors
+          reject(mockedErrorMessage);
+        })
+    );
+    jest.spyOn(navigator.clipboard, 'writeText').mockImplementation(mockWriteTextWithError);
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(expectedError);
+    expect(mockWriteTextWithError).toHaveBeenCalledWith(mockTextToCopy);
+    expect(result.current[0].success).toEqual(false);
+    expect(result.current[0].error).toEqual(expectedError);
+    expect(result.current[0].value).toBeUndefined();
+  });
+
+  it('should create unexpected error otherwise', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCopyToClipboard());
+    const expectedError = new Error('Unexpected error occured copying data to clipboard');
+    const mockWriteTextWithError = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          reject();
+        })
+    );
+    jest.spyOn(navigator.clipboard, 'writeText').mockImplementation(mockWriteTextWithError);
+
+    await act(() => {
+      result.current[1](mockTextToCopy);
+      return waitForNextUpdate();
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(expectedError);
+    expect(mockWriteTextWithError).toHaveBeenCalledWith(mockTextToCopy);
+    expect(result.current[0].success).toEqual(false);
+    expect(result.current[0].error).toEqual(expectedError);
+    expect(result.current[0].value).toBeUndefined();
+  });
+});

--- a/src/useCopyToClipboard/__tests__/ssr.ts
+++ b/src/useCopyToClipboard/__tests__/ssr.ts
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useCopyToClipboard } from '../..';
+
+describe('useCopyToClipboard', () => {
+  it('should be defined', () => {
+    expect(useCopyToClipboard).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should return a 3 elements array', () => {
+    const result = renderHook(() => useCopyToClipboard());
+    expect(result.result.current).toHaveLength(3);
+  });
+});

--- a/src/useCopyToClipboard/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard/useCopyToClipboard.ts
@@ -1,0 +1,83 @@
+import { useCallback } from 'react';
+import { useSafeState } from '..';
+
+export type CopyToClipboardState =
+  | {
+      value: undefined;
+      success: undefined;
+      error: undefined;
+    }
+  | {
+      value: string;
+      success: true;
+      error?: undefined;
+    }
+  | {
+      success: false;
+      value?: undefined;
+      error: Error;
+    };
+
+const initialState: CopyToClipboardState = {
+  value: undefined,
+  success: undefined,
+  error: undefined,
+};
+
+/**
+ * Utility to copy some text to clipboard with additionnal checks to avoid unexpected errors and
+ * to keep async logic out of `copyToClipboard` callback that would change its return type to
+ * `Promise<void>` which could unnecessarily complexify calling contexts.
+ * @param textToCopy text to copy to the clipboard, must be a string
+ */
+async function performCopyToClipboard(textToCopy: string): Promise<void> {
+  try {
+    if (typeof textToCopy !== 'string') {
+      throw new TypeError('Data to copy must be a string');
+    }
+
+    if (!navigator.clipboard) {
+      throw new Error('Clipboard API not supported by the browser');
+    }
+
+    await navigator.clipboard.writeText(textToCopy);
+  } catch (error) {
+    let parsedError: Error;
+    if (error instanceof Error) {
+      parsedError = error;
+    } else if (typeof error === 'string') {
+      parsedError = new Error(error);
+    } else {
+      parsedError = new Error('Unexpected error occured copying data to clipboard');
+    }
+    throw parsedError;
+  }
+}
+
+export function useCopyToClipboard(): [
+  copyState: CopyToClipboardState,
+  copyToClipboard: (text: string) => void,
+  resetCopyState: () => void
+] {
+  const [copyState, setCopyState] = useSafeState<CopyToClipboardState>(initialState);
+
+  const resetState = useCallback(() => {
+    setCopyState(initialState);
+  }, [setCopyState]);
+
+  const copyToClipboard = useCallback(
+    (text: string) => {
+      performCopyToClipboard(text)
+        .then(() => setCopyState({ success: true, value: text }))
+        .catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn(error);
+          // error casted as Error because ensured by performCopyToClipboard's try/catch
+          setCopyState({ success: false, error: error as Error });
+        });
+    },
+    [setCopyState]
+  );
+
+  return [copyState, copyToClipboard, resetState];
+}


### PR DESCRIPTION
## What new hook does?
New hook inspired by react-use's `useCopyToClipboard`, copies some text to clipboard. It returns an array composed as follow:
- a `copyState` that reflects copy process (if successful, erroneous and what data has been copied),
- `copyToClipboard`, main callback to copy a string into clipboard
- `resetCopyState`, new callback not present in react-use's implementation to easily reset `copyState` to initial value (all fields undefined)

Countrary to react-use's implementation, this hook does not rely on `copy-to-clipboard` external dependency. Instead it simply uses [navigator.clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) which seems to have good support on major browser vendors (see [caniuse compatibly table](https://caniuse.com/?search=navigator.clipboard)). The `noUserInteraction: boolean` has been removed from `copyState` because it seemed specific to `copy-to-clipboard` usage.

Also added a `success: boolean` field in `copyState` to ease usage but this is up to debate since we could do as react-use's implementation and only rely on `value` not being undefined.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  - #33 (useCopyToClipboard)
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
