### PR TITLE
feat(useTimeoutEffect): Implement useTimeoutEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Coming from `react-use`? Check out our
     — Return callback that re-renders component.
   - [**`useThrottledEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usethrottledeffect--example)
     — Like `useEffect`, but passed function is throttled.
+  - [**`useTimeoutEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usetimeouteffect--example)
+    — Like `setTimeout`, but in the form of a react hook.
   - [**`useUnmountEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useunmounteffect--example)
     — Run effect only when component unmounted.
   - [**`useUpdateEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useupdateeffect--example)

--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -243,11 +243,41 @@ Not implemented yet
 
 #### useTimeout
 
-Not implemented yet
+No plans to implement, rather use [useTimeoutEffect](/docs/lifecycle-usetimeouteffect--example) and [useRerender](/docs/lifecycle-usererender--example) like this:
+
+```javascript
+const rerender = useRerender();
+const [cancel, reset] = useTimeoutEffect(rerender, 123);
+```
 
 #### useTimeoutFn
 
-Not implemented yet
+Implemented as [useTimeoutEffect](/docs/lifecycle-usetimeouteffect--example)
+
+API is backwards-compatible, minus the first `isReady` return value.
+
+In order to replicate the old functionality, you can do the following:
+
+```javascript
+const isReady = (React.useRef < boolean) | (null > false);
+
+const [cancel, reset] = useTimeoutEffect(() => {
+  isReady.current = true;
+  console.log('Hello world');
+}, 123);
+
+const clear = () => {
+  isReady.current = null;
+  cancel();
+};
+
+const set = () => {
+  isReady.current = false;
+  reset();
+};
+
+// Use set and clear, same as in `react-use`.
+```
 
 #### useTween
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export { useUnmountEffect } from './useUnmountEffect/useUnmountEffect';
 export { useUpdateEffect } from './useUpdateEffect/useUpdateEffect';
 export { useLifecycleLogger } from './useLifecycleLogger/useLifecycleLogger';
 export { useIntervalEffect } from './useIntervalEffect/useIntervalEffect';
+export { useTimeoutEffect } from './useTimeoutEffect/useTimeoutEffect';
 
 // State
 export { useControlledRerenderState } from './useControlledRerenderState/useControlledRerenderState';

--- a/src/useTimeoutEffect/__docs__/example.stories.tsx
+++ b/src/useTimeoutEffect/__docs__/example.stories.tsx
@@ -23,6 +23,7 @@ export const Example: React.FC = () => {
 
   React.useEffect(() => {
     setNumCalls(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeoutValue, enabled]);
 
   return (

--- a/src/useTimeoutEffect/__docs__/example.stories.tsx
+++ b/src/useTimeoutEffect/__docs__/example.stories.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { useSafeState, useTimeoutEffect, useToggle } from '../..';
+
+export const Example: React.FC = () => {
+  const [numCalls, setNumCalls] = useSafeState<number>(0);
+  const [enabled, toggleEnabled] = useToggle();
+  const [timeoutValue, setTimeoutValue] = useSafeState<number>(1000);
+  const [cancelled, toggleCancelled] = useToggle();
+
+  let status;
+  if (cancelled) {
+    status = 'Cancelled';
+  } else {
+    status = enabled ? 'Enabled' : 'Disabled';
+  }
+
+  const [cancel, reset] = useTimeoutEffect(
+    () => {
+      setNumCalls((n) => n + 1);
+    },
+    enabled ? timeoutValue : undefined
+  );
+
+  React.useEffect(() => {
+    setNumCalls(0);
+  }, [timeoutValue, enabled]);
+
+  return (
+    <div>
+      Has fired: {numCalls.toString()}
+      <br />
+      Status: {status}
+      <br />
+      <input
+        placeholder="Timeout value"
+        type="number"
+        min={0}
+        value={timeoutValue}
+        onChange={(e) => setTimeoutValue(Number(e.target.value))}
+      />
+      <button
+        onClick={() => {
+          toggleEnabled();
+          toggleCancelled(false);
+        }}>
+        {enabled ? 'Disable' : 'Enable'} timeout
+      </button>
+      <button
+        onClick={() => {
+          reset();
+          toggleCancelled(false);
+        }}>
+        Reset
+      </button>
+      <button
+        onClick={() => {
+          cancel();
+          toggleCancelled(enabled && true);
+        }}>
+        Cancel
+      </button>
+    </div>
+  );
+};

--- a/src/useTimeoutEffect/__docs__/story.mdx
+++ b/src/useTimeoutEffect/__docs__/story.mdx
@@ -1,0 +1,41 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Example } from './example.stories';
+import { ImportPath } from '../../__docs__/ImportPath';
+
+<Meta title="Lifecycle/useTimeoutEffect" component={Example} />
+
+# useTimeoutEffect
+
+Like `setTimeout` but in the form of a react hook.
+
+- Auto-cancels the timeout on component unmount.
+- Resets the timeout on delay change.
+- Changing the callback won't cause the timeout to reset.
+- Ability to cancel the timeout.
+- Ability to reset the timeout.
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+export function useTimeoutEffect(callback: () => void, ms?: number): void;
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+- **callback** _`() => void`_ - Function to be called after timeout.
+- **ms** _`number | undefined`_ - Delay passed to underlying `setTimeout`. If `undefined` the interval will be cancelled.
+
+#### Return
+
+1. **cancel** _`() => void`_ - Function to cancel the timeout.
+2. **reset** _`() => void`_ - Function to reset the timeout.

--- a/src/useTimeoutEffect/__tests__/dom.ts
+++ b/src/useTimeoutEffect/__tests__/dom.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useTimeoutEffect } from '../..';
+
+describe('useTimeoutEffect', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should be defined', () => {
+    expect(useTimeoutEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useTimeoutEffect(() => {}, 123));
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should set and call function after timeout', () => {
+    const spy = jest.fn();
+    renderHook(() => useTimeoutEffect(spy, 100));
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should set timeout and cancel on unmount', () => {
+    const spy = jest.fn();
+    const { unmount } = renderHook(() => useTimeoutEffect(spy, 100));
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+    unmount();
+    jest.advanceTimersByTime(1);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should reset timeout in delay change', () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(({ delay }) => useTimeoutEffect(spy, delay), {
+      initialProps: { delay: 100 },
+    });
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender({ delay: 50 });
+    jest.advanceTimersByTime(49);
+    expect(spy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not reset timeout in callback change', () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(({ callback }) => useTimeoutEffect(callback, 100), {
+      initialProps: { callback: () => {} },
+    });
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender({ callback: () => spy() });
+    jest.advanceTimersByTime(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cancel timeout if delay is undefined', () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(({ delay }) => useTimeoutEffect(spy, delay), {
+      initialProps: { delay: 100 } as { delay: number | undefined },
+    });
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender({ delay: undefined });
+    jest.advanceTimersByTime(2000);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should not cancel timeout if delay is 0', () => {
+    const spy = jest.fn();
+    renderHook(() => useTimeoutEffect(spy, 0));
+
+    jest.advanceTimersByTime(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cancel timeout if cancel method is called', () => {
+    const spy = jest.fn();
+    const { result } = renderHook(() => useTimeoutEffect(spy, 100));
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+
+    result.current[0]();
+    jest.advanceTimersByTime(1);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should reset timeout if reset method is called', () => {
+    const spy = jest.fn();
+    const { result } = renderHook(() => useTimeoutEffect(spy, 100));
+
+    jest.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+
+    result.current[1]();
+    jest.advanceTimersByTime(1);
+    expect(spy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(100);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/useTimeoutEffect/__tests__/ssr.ts
+++ b/src/useTimeoutEffect/__tests__/ssr.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useTimeoutEffect } from '../..';
+
+describe('useTimeoutEffect', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should be defined', () => {
+    expect(useTimeoutEffect).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useTimeoutEffect(() => {}, 123));
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should not invoke callback after timeout', () => {
+    const spy = jest.fn();
+    renderHook(() => useTimeoutEffect(spy, 100));
+
+    jest.advanceTimersByTime(100);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/useTimeoutEffect/useTimeoutEffect.ts
+++ b/src/useTimeoutEffect/useTimeoutEffect.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSyncedRef } from '..';
+
+type TimeoutID = ReturnType<typeof setTimeout> | null;
+
+const cancelTimeout = (id: TimeoutID) => {
+  if (id) {
+    clearTimeout(id);
+  }
+};
+
+/**
+ * Like `setTimeout` but in the form of a react hook.
+ *
+ * @param callback Callback to be called after the timeout. Changing this
+ * will not reset the timeout.
+ * @param ms Timeout delay in milliseconds. `undefined` disables the timeout.
+ * Keep in mind, that changing this parameter will re-set timeout, meaning
+ * that it will be set as new after the change.
+ */
+export function useTimeoutEffect(
+  callback: () => void,
+  ms?: number
+): [cancel: () => void, reset: () => void] {
+  const cbRef = useSyncedRef(callback);
+  const msRef = useSyncedRef(ms);
+  const timeoutIdRef = useRef<TimeoutID>(null);
+
+  const cancel = useCallback(() => {
+    cancelTimeout(timeoutIdRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const reset = useCallback(() => {
+    if (typeof msRef.current === 'undefined') return;
+
+    cancel();
+    timeoutIdRef.current = setTimeout(() => cbRef.current(), msRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    reset();
+    return cancel;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ms]);
+
+  return [cancel, reset];
+}


### PR DESCRIPTION
## What new hook does?
Functions like `setTimeout`, except in hook form. Returns a method to cancel the timeout, and a method to restart the timeout. It does not cause any rerenders.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  - https://github.com/react-hookz/web/issues/33
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
