### PR TITLE
Add an optional argument to useIntervalEffect to synchronise updates

### DIFF
--- a/src/useIntervalEffect/useIntervalEffect.ts
+++ b/src/useIntervalEffect/useIntervalEffect.ts
@@ -2,14 +2,47 @@ import { useEffect } from 'react';
 import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 /**
+ * A Map of delay -> `callSynchronized` intervals for removal when unused.
+ */
+const intervalMap = new Map<number, ReturnType<typeof setInterval>>();
+
+/**
+ * A Map of delay -> callbacks array.
+ *
+ * Note that the array is mutable: a single array that is changed as entries are
+ * added and removed, rather than spamming the GC when anything changes.
+ */
+const callbackMap = new Map<number, Array<{ current: () => void }>>();
+
+/**
+ * Call all functions that have the same delay sequentially.
+ *
+ * @param ms Interval delay in milliseconds.
+ */
+const callSynchronized = (ms: number) => {
+  const callbacks = callbackMap.get(ms);
+
+  if (callbacks) {
+    for (const callback of callbacks) {
+      try {
+        callback.current();
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+};
+
+/**
  * Like `setInterval` but in form of react hook.
  *
  * @param callback Callback to be called within interval.
  * @param ms Interval delay in milliseconds, `undefined` disables the interval.
  * Keep in mind, that changing this parameter will re-set interval, meaning
  * that it will be set as new after the change.
+ * @param synchronize Should all callbacks on the same delay fire simultaniously.
  */
-export function useIntervalEffect(callback: () => void, ms?: number): void {
+export function useIntervalEffect(callback: () => void, ms?: number, synchronize = false): void {
   const cbRef = useSyncedRef(callback);
 
   useEffect(() => {
@@ -17,9 +50,29 @@ export function useIntervalEffect(callback: () => void, ms?: number): void {
       return;
     }
 
-    const id = setInterval(() => cbRef.current(), ms);
+    if (synchronize) {
+      if (callbackMap.has(ms)) {
+        callbackMap.get(ms)!.splice(-1, 0, cbRef);
+      } else {
+        callbackMap.set(ms, [cbRef]);
+      }
+      if (!intervalMap.has(ms)) {
+        intervalMap.set(ms, setInterval(callSynchronized, ms, ms));
+      }
 
-    return () => clearInterval(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ms]);
+      return () => {
+        const callbacks = callbackMap.get(ms);
+
+        if (!callbacks?.splice(callbacks.indexOf(cbRef), 1).length) {
+          clearInterval(intervalMap.get(ms)!);
+          callbackMap.delete(ms);
+          intervalMap.delete(ms);
+        }
+      };
+    } else {
+      const id = setInterval(() => cbRef.current(), ms);
+
+      return () => clearInterval(id);
+    }
+  }, [ms, !synchronize]);
 }


### PR DESCRIPTION
Sadly not got time to do the documentation and tests for this in the next couple of weeks at least - but if anyone wants to add those bits to get this to a mergeable point then go for it!

This adds an optional synchronisation to useIntervalEffect - in other words, anything that uses the option and has the same update time will be called in the same update cycle. For instance allowing for multiple clocks on screen that all update in the same tick etc.

It uses two Maps, one simply stores the `setInterval` result so it can be removed when unused, and the second stores an array of callbacks. Whenever a callback is added or removed the array is mutated (rather than replaced - GC reasons mainly), and the callbacks themselves are wrapped in try/catch so they don't break anything. The dependencies list adds the flag coerced into a boolean - don't care what it actually is, but `undefined == false` and hooks use `===` so it saves processing on that edge case of `undefined` -> `false`.
