### PR TITLE
style: removes circular imports from the library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ If you are contributing for the first time - we would recommend reading
    - In case hook is stateful and exposes `setState` method, or is has async callbacks (that can
      theoretically be resolved after component unmount), it should use `useSafeState` instead of
      `useState`.
-   - In case of hooks reuse, import them as `import { useSafeState } from '..';` instead of
-     `import { useSafeState } from '../useSafeState/useSafeState';`
+   - In case of hooks reuse, import them as `import { useSafeState } from '../useSafeState/useSafeState';` instead of
+     `import { useSafeState } from '..';`
 2. Reexport hook implementation and all custom types in `src/index.ts`.
    - Custom types should be also reexported.
 3. Write complete tests for your hook, tests should consist of both DOM and SSR parts.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,11 @@
-/* eslint-disable import/no-cycle */
 // Callback
 export { useDebouncedCallback } from './useDebouncedCallback/useDebouncedCallback';
 export { useRafCallback } from './useRafCallback/useRafCallback';
 export { useThrottledCallback } from './useThrottledCallback/useThrottledCallback';
 
 // Lifecycle
-export {
-  useConditionalEffect,
-  ConditionsPredicate,
-  ConditionsList,
-} from './useConditionalEffect/useConditionalEffect';
-export {
-  useCustomCompareEffect,
-  DependenciesComparator,
-} from './useCustomCompareEffect/useCustomCompareEffect';
+export { useConditionalEffect } from './useConditionalEffect/useConditionalEffect';
+export { useCustomCompareEffect } from './useCustomCompareEffect/useCustomCompareEffect';
 export { useDebouncedEffect } from './useDebouncedEffect/useDebouncedEffect';
 export { useDeepCompareEffect } from './useDeepCompareEffect/useDeepCompareEffect';
 export { useFirstMountState } from './useFirstMountState/useFirstMountState';
@@ -38,7 +30,7 @@ export { useList } from './useList/useList';
 export { useMap } from './useMap/useMap';
 export { useMediatedState } from './useMediatedState/useMediatedState';
 export { usePrevious } from './usePrevious/usePrevious';
-export { usePreviousDistinct, Predicate } from './usePreviousDistinct/usePreviousDistinct';
+export { usePreviousDistinct } from './usePreviousDistinct/usePreviousDistinct';
 export { useRafState } from './useRafState/useRafState';
 export { useSafeState } from './useSafeState/useSafeState';
 export { useSet } from './useSet/useSet';
@@ -119,3 +111,11 @@ export { truthyAndArrayPredicate, truthyOrArrayPredicate } from './util/const';
 export { EffectCallback, EffectHook } from './util/misc';
 
 export { resolveHookState } from './util/resolveHookState';
+
+// Types
+export type {
+  DependenciesComparator,
+  Predicate,
+  ConditionsList,
+  ConditionsPredicate,
+} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,9 +113,4 @@ export { EffectCallback, EffectHook } from './util/misc';
 export { resolveHookState } from './util/resolveHookState';
 
 // Types
-export type {
-  DependenciesComparator,
-  Predicate,
-  ConditionsList,
-  ConditionsPredicate,
-} from './types';
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+import { DependencyList } from 'react';
+
+export type DependenciesComparator<Deps extends DependencyList = DependencyList> = (
+  a: Deps,
+  b: Deps
+) => boolean;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Predicate = (prev: any, next: any) => boolean;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ConditionsList = ReadonlyArray<any>;
+
+export type ConditionsPredicate<Cond extends ConditionsList = ConditionsList> = (
+  conditions: Cond
+) => boolean;

--- a/src/useAsync/useAsync.ts
+++ b/src/useAsync/useAsync.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
-import { useSafeState, useSyncedRef } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 export type AsyncStatus = 'loading' | 'success' | 'error' | 'not-executed';
 

--- a/src/useAsyncAbortable/useAsyncAbortable.ts
+++ b/src/useAsyncAbortable/useAsyncAbortable.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
-import { AsyncState, UseAsyncActions, UseAsyncMeta, useAsync } from '..';
+
+import { useAsync, UseAsyncMeta, UseAsyncActions, AsyncState } from '../useAsync/useAsync';
 
 export interface UseAsyncAbortableActions<Result, Args extends unknown[] = unknown[]>
   extends UseAsyncActions<Result, Args> {

--- a/src/useAsyncAbortable/useAsyncAbortable.ts
+++ b/src/useAsyncAbortable/useAsyncAbortable.ts
@@ -1,5 +1,4 @@
 import { useMemo, useRef } from 'react';
-
 import { useAsync, UseAsyncMeta, UseAsyncActions, AsyncState } from '../useAsync/useAsync';
 
 export interface UseAsyncAbortableActions<Result, Args extends unknown[] = unknown[]>

--- a/src/useClickOutside/useClickOutside.ts
+++ b/src/useClickOutside/useClickOutside.ts
@@ -1,6 +1,6 @@
 import { MutableRefObject, RefObject, useEffect } from 'react';
 import { off, on } from '../util/misc';
-import { useSyncedRef } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 const DEFAULT_EVENTS = ['mousedown', 'touchstart'];
 

--- a/src/useConditionalEffect/useConditionalEffect.ts
+++ b/src/useConditionalEffect/useConditionalEffect.ts
@@ -1,12 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList, useEffect } from 'react';
-import { EffectCallback, EffectHook, truthyAndArrayPredicate } from '..';
-
-export type ConditionsList = ReadonlyArray<any>;
-
-export type ConditionsPredicate<Cond extends ConditionsList = ConditionsList> = (
-  conditions: Cond
-) => boolean;
+import { truthyAndArrayPredicate } from '../util/const';
+import { EffectHook, EffectCallback } from '../util/misc';
+import type { ConditionsList, ConditionsPredicate } from '../types';
 
 /**
  * Like `useEffect` but callback invoked only if conditions match predicate.

--- a/src/useControlledRerenderState/useControlledRerenderState.ts
+++ b/src/useControlledRerenderState/useControlledRerenderState.ts
@@ -1,5 +1,6 @@
 import { SetStateAction, useCallback, useRef } from 'react';
-import { useFirstMountState, useRerender } from '..';
+import { useFirstMountState } from '../useFirstMountState/useFirstMountState';
+import { useRerender } from '../useRerender/useRerender';
 import { resolveHookState } from '../util/resolveHookState';
 
 export type ControlledRerenderDispatch<A> = (value: A, rerender?: boolean) => void;

--- a/src/useCookieValue/useCookieValue.ts
+++ b/src/useCookieValue/useCookieValue.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define,no-use-before-define */
 import Cookies from 'js-cookie';
 import { Dispatch, useCallback, useEffect } from 'react';
-import { useFirstMountState, useMountEffect, useSafeState, useSyncedRef } from '..';
+import { useFirstMountState } from '../useFirstMountState/useFirstMountState';
+import { useMountEffect } from '../useMountEffect/useMountEffect';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { isBrowser } from '../util/const';
 
 const cookiesSetters = new Map<string, Set<Dispatch<string | null>>>();

--- a/src/useCounter/useCounter.ts
+++ b/src/useCounter/useCounter.ts
@@ -1,5 +1,6 @@
 import { SetStateAction, useMemo } from 'react';
-import { useMediatedState, useSyncedRef } from '..';
+import { useMediatedState } from '../useMediatedState/useMediatedState';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { InitialState, resolveHookState } from '../util/resolveHookState';
 
 export interface CounterActions {

--- a/src/useCustomCompareEffect/useCustomCompareEffect.ts
+++ b/src/useCustomCompareEffect/useCustomCompareEffect.ts
@@ -1,13 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList, useEffect, useRef } from 'react';
 import { isBrowser } from '../util/const';
-// eslint-disable-next-line import/no-cycle
 import { basicDepsComparator } from '../util/misc';
-
-export type DependenciesComparator<Deps extends DependencyList = DependencyList> = (
-  a: Deps,
-  b: Deps
-) => boolean;
+import type { DependenciesComparator } from '../types';
 
 export type EffectCallback = (...args: any[]) => any;
 

--- a/src/useCustomCompareMemo/useCustomCompareMemo.ts
+++ b/src/useCustomCompareMemo/useCustomCompareMemo.ts
@@ -1,5 +1,4 @@
 import { useMemo, useRef } from 'react';
-
 import type { DependencyList } from 'react';
 import type { DependenciesComparator } from '../types';
 

--- a/src/useCustomCompareMemo/useCustomCompareMemo.ts
+++ b/src/useCustomCompareMemo/useCustomCompareMemo.ts
@@ -1,7 +1,7 @@
 import { useMemo, useRef } from 'react';
 
 import type { DependencyList } from 'react';
-import type { DependenciesComparator } from '..';
+import type { DependenciesComparator } from '../types';
 
 /**
  * Like useMemo but uses provided comparator function to validate dependency changes.

--- a/src/useDebouncedEffect/useDebouncedEffect.ts
+++ b/src/useDebouncedEffect/useDebouncedEffect.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList, useEffect } from 'react';
-import { useDebouncedCallback } from '..';
+import { useDebouncedCallback } from '../useDebouncedCallback/useDebouncedCallback';
 
 /**
  * Like `useEffect`, but passed function is debounced.

--- a/src/useDebouncedState/useDebouncedState.ts
+++ b/src/useDebouncedState/useDebouncedState.ts
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
-import { useDebouncedCallback, useSafeState } from '..';
+import { useDebouncedCallback } from '../useDebouncedCallback/useDebouncedCallback';
+import { useSafeState } from '../useSafeState/useSafeState';
 
 /**
  * Like `useSafeState` but its state setter is debounced.

--- a/src/useDocumentTitle/useDocumentTitle.ts
+++ b/src/useDocumentTitle/useDocumentTitle.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { isBrowser } from '../util/const';
-import { useUnmountEffect, useSyncedRef } from '..';
+import { useUnmountEffect } from '../useUnmountEffect/useUnmountEffect';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 export interface UseDocumentTitleOptions {
   /**

--- a/src/useEventListener/useEventListener.ts
+++ b/src/useEventListener/useEventListener.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { RefObject, useEffect, useMemo } from 'react';
-import { useIsMounted, useSyncedRef } from '..';
+import { useIsMounted } from '../useIsMounted/useIsMounted';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { hasOwnProperty } from '../util/misc';
 
 /**

--- a/src/useHookableRef/useHookableRef.ts
+++ b/src/useHookableRef/useHookableRef.ts
@@ -1,5 +1,5 @@
 import { MutableRefObject, useMemo } from 'react';
-import { useSyncedRef } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 export type HookableRefHandler<T> = (v: T) => T;
 

--- a/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -1,5 +1,5 @@
 import { RefObject, useEffect } from 'react';
-import { useSafeState } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
 
 const DEFAULT_THRESHOLD = [0];
 const DEFAULT_ROOT_MARGIN = '0px';

--- a/src/useKeyboardEvent/useKeyboardEvent.ts
+++ b/src/useKeyboardEvent/useKeyboardEvent.ts
@@ -1,5 +1,6 @@
 import { DependencyList, RefObject, useMemo } from 'react';
-import { useEventListener, useSyncedRef } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
+import { useEventListener } from '../useEventListener/useEventListener';
 import { isBrowser } from '../util/const';
 import { yieldFalse, yieldTrue } from '../util/misc';
 

--- a/src/useList/useList.ts
+++ b/src/useList/useList.ts
@@ -1,6 +1,7 @@
 import { SetStateAction, useMemo, useRef } from 'react';
 import { InitialState, resolveHookState } from '../util/resolveHookState';
-import { useRerender, useSyncedRef } from '..';
+import { useRerender } from '../useRerender/useRerender';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 export interface ListActions<T> {
   /**

--- a/src/useMap/useMap.ts
+++ b/src/useMap/useMap.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useRerender } from '..';
+import { useRerender } from '../useRerender/useRerender';
 
 const proto = Map.prototype;
 

--- a/src/useMeasure/useMeasure.ts
+++ b/src/useMeasure/useMeasure.ts
@@ -1,11 +1,11 @@
 import { MutableRefObject } from 'react';
 import {
   UseResizeObserverCallback,
-  useHookableRef,
-  useRafCallback,
   useResizeObserver,
-  useSafeState,
-} from '..';
+} from '../useResizeObserver/useResizeObserver';
+import { useHookableRef } from '../useHookableRef/useHookableRef';
+import { useRafCallback } from '../useRafCallback/useRafCallback';
+import { useSafeState } from '../useSafeState/useSafeState';
 
 /**
  * Uses ResizeObserver to track element dimensions and re-render component when they change.

--- a/src/useMediaQuery/useMediaQuery.ts
+++ b/src/useMediaQuery/useMediaQuery.ts
@@ -1,5 +1,5 @@
 import { Dispatch, useEffect } from 'react';
-import { useSafeState } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
 
 const queriesMap = new Map<
   string,

--- a/src/useMediatedState/useMediatedState.ts
+++ b/src/useMediatedState/useMediatedState.ts
@@ -1,5 +1,6 @@
 import { Dispatch, useCallback } from 'react';
-import { useSafeState, useSyncedRef } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { InitialState, NextState, resolveHookState } from '../util/resolveHookState';
 
 export function useMediatedState<State = undefined>(): [

--- a/src/useNetworkState/useNetworkState.ts
+++ b/src/useNetworkState/useNetworkState.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { isBrowser } from '../util/const';
-import { useSafeState } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
 import { off, on } from '../util/misc';
 import { InitialState } from '../util/resolveHookState';
 

--- a/src/usePermission/usePermission.ts
+++ b/src/usePermission/usePermission.ts
@@ -1,5 +1,5 @@
 import { MutableRefObject, useEffect } from 'react';
-import { useSafeState } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
 import { off, on } from '../util/misc';
 
 export type UsePermissionState = PermissionState | 'not-requested' | 'requested';

--- a/src/usePreviousDistinct/usePreviousDistinct.ts
+++ b/src/usePreviousDistinct/usePreviousDistinct.ts
@@ -1,10 +1,7 @@
 import { useRef, useState } from 'react';
-import { useUpdateEffect } from '..';
+import { useUpdateEffect } from '../useUpdateEffect/useUpdateEffect';
 import { isStrictEqual } from '../util/const';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Predicate = (prev: any, next: any) => boolean;
-
+import type { Predicate } from '../types';
 /**
  * Returns the most recent _distinct_ value passed to the hook on previous render. Distinct here
  * means that the hook's return value will only update when the passed value updates. This is

--- a/src/useRafCallback/useRafCallback.ts
+++ b/src/useRafCallback/useRafCallback.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
-import { useSyncedRef, useUnmountEffect } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
+import { useUnmountEffect } from '../useUnmountEffect/useUnmountEffect';
 import { isBrowser } from '../util/const';
 
 /**

--- a/src/useRafEffect/useRafEffect.ts
+++ b/src/useRafEffect/useRafEffect.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList, useEffect } from 'react';
-import { useRafCallback } from '..';
+import { useRafCallback } from '../useRafCallback/useRafCallback';
 
 /**
  * Like `React.useEffect`, but state is only updated within animation frame.

--- a/src/useRafState/useRafState.ts
+++ b/src/useRafState/useRafState.ts
@@ -1,5 +1,7 @@
 import { Dispatch, SetStateAction } from 'react';
-import { useRafCallback, useSafeState, useUnmountEffect } from '..';
+import { useRafCallback } from '../useRafCallback/useRafCallback';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useUnmountEffect } from '../useUnmountEffect/useUnmountEffect';
 
 export function useRafState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
 export function useRafState<S = undefined>(): [

--- a/src/useRerender/useRerender.ts
+++ b/src/useRerender/useRerender.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useSafeState } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
 
 const stateChanger = (state: number) => (state + 1) % Number.MAX_SAFE_INTEGER;
 

--- a/src/useResizeObserver/useResizeObserver.ts
+++ b/src/useResizeObserver/useResizeObserver.ts
@@ -1,5 +1,5 @@
 import { RefObject, useEffect } from 'react';
-import { useSyncedRef } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { isBrowser } from '../util/const';
 
 export type UseResizeObserverCallback = (entry: ResizeObserverEntry) => void;

--- a/src/useSafeState/useSafeState.ts
+++ b/src/useSafeState/useSafeState.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction, useCallback, useState } from 'react';
-import { useIsMounted } from '..';
+import { useIsMounted } from '../useIsMounted/useIsMounted';
 
 export function useSafeState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
 export function useSafeState<S = undefined>(): [

--- a/src/useScreenOrientation/useScreenOrientation.ts
+++ b/src/useScreenOrientation/useScreenOrientation.ts
@@ -1,4 +1,4 @@
-import { useMediaQuery } from '..';
+import { useMediaQuery } from '../useMediaQuery/useMediaQuery';
 
 export type ScreenOrientation = 'portrait' | 'landscape';
 

--- a/src/useSet/useSet.ts
+++ b/src/useSet/useSet.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useRerender } from '..';
+import { useRerender } from '../useRerender/useRerender';
 
 const proto = Set.prototype;
 

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -1,15 +1,13 @@
 /* eslint-disable @typescript-eslint/no-use-before-define,no-use-before-define */
 import { useCallback } from 'react';
-import {
-  useConditionalEffect,
-  useFirstMountState,
-  useIsomorphicLayoutEffect,
-  useMountEffect,
-  usePrevious,
-  useSafeState,
-  useSyncedRef,
-  useUpdateEffect,
-} from '..';
+import { useConditionalEffect } from '../useConditionalEffect/useConditionalEffect';
+import { useFirstMountState } from '../useFirstMountState/useFirstMountState';
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomorphicLayoutEffect';
+import { useMountEffect } from '../useMountEffect/useMountEffect';
+import { usePrevious } from '../usePrevious/usePrevious';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
+import { useUpdateEffect } from '../useUpdateEffect/useUpdateEffect';
 import { NextState, resolveHookState } from '../util/resolveHookState';
 import { isBrowser } from '../util/const';
 import { off, on } from '../util/misc';

--- a/src/useThrottledCallback/useThrottledCallback.ts
+++ b/src/useThrottledCallback/useThrottledCallback.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList, useMemo, useRef } from 'react';
-import { useUnmountEffect } from '..';
+import { useUnmountEffect } from '../useUnmountEffect/useUnmountEffect';
 
 export interface ThrottledFunction<Fn extends (...args: any[]) => any> {
   (this: ThisParameterType<Fn>, ...args: Parameters<Fn>): void;

--- a/src/useThrottledEffect/useThrottledEffect.ts
+++ b/src/useThrottledEffect/useThrottledEffect.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList, useEffect } from 'react';
-import { useThrottledCallback } from '..';
+import { useThrottledCallback } from '../useThrottledCallback/useThrottledCallback';
 
 /**
  * Like `useEffect`, but passed function is throttled.

--- a/src/useThrottledState/useThrottledState.ts
+++ b/src/useThrottledState/useThrottledState.ts
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
-import { useSafeState, useThrottledCallback } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useThrottledCallback } from '../useThrottledCallback/useThrottledCallback';
 
 /**
  * Like `useSafeState` but its state setter is throttled.

--- a/src/useTimeoutEffect/useTimeoutEffect.ts
+++ b/src/useTimeoutEffect/useTimeoutEffect.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { useSyncedRef } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 
 type TimeoutID = ReturnType<typeof setTimeout> | null;
 

--- a/src/useToggle/useToggle.ts
+++ b/src/useToggle/useToggle.ts
@@ -1,5 +1,6 @@
 import { BaseSyntheticEvent, useCallback } from 'react';
-import { useSafeState, useSyncedRef } from '..';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
+import { useSafeState } from '../useSafeState/useSafeState';
 import { InitialState, NextState, resolveHookState } from '../util/resolveHookState';
 
 export function useToggle(

--- a/src/useUpdateEffect/useUpdateEffect.ts
+++ b/src/useUpdateEffect/useUpdateEffect.ts
@@ -1,5 +1,5 @@
 import { DependencyList, EffectCallback, useEffect } from 'react';
-import { useFirstMountState } from '..';
+import { useFirstMountState } from '../useFirstMountState/useFirstMountState';
 import { noop } from '../util/const';
 
 /**

--- a/src/useValidator/useValidator.ts
+++ b/src/useValidator/useValidator.ts
@@ -1,5 +1,6 @@
 import { DependencyList, Dispatch, useCallback, useEffect } from 'react';
-import { useSafeState, useSyncedRef } from '..';
+import { useSafeState } from '../useSafeState/useSafeState';
+import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { InitialState, NextState } from '../util/resolveHookState';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/useWindowSize/useWindowSize.ts
+++ b/src/useWindowSize/useWindowSize.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
-import { useFirstMountState, useMountEffect, useRafState } from '..';
+import { useFirstMountState } from '../useFirstMountState/useFirstMountState';
+import { useMountEffect } from '../useMountEffect/useMountEffect';
+import { useRafState } from '../useRafState/useRafState';
 import { isBrowser } from '../util/const';
 
 export interface WindowSize {

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,4 +1,4 @@
-import { ConditionsPredicate, Predicate } from '..';
+import type { Predicate, ConditionsPredicate } from '../types';
 
 export const noop = (): void => {};
 

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any,import/no-cycle */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { DependencyList } from 'react';
-import { DependenciesComparator } from '../useCustomCompareEffect/useCustomCompareEffect';
+import type { DependenciesComparator } from '../types';
 
 export function on<T extends EventTarget>(
   obj: T | null,


### PR DESCRIPTION
This library is being detected as having circular imports which can prevent its use in some projects. This changes all the `import {<thing>} from '..'` lines to instead import directly from the files that have the required dependencies. This also moves some types to their own file to remove circular imports from the `utils` directory. Otherwise this change makes no functional change to any hooks.

Will close #905 
