### PR TITLE
fix(useStorageValue): Allow setting of state even if the component has not mounted

### DIFF
--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define,no-use-before-define */
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useConditionalEffect } from '../useConditionalEffect/useConditionalEffect';
 import { useFirstMountState } from '../useFirstMountState/useFirstMountState';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomorphicLayoutEffect';
 import { useMountEffect } from '../useMountEffect/useMountEffect';
 import { usePrevious } from '../usePrevious/usePrevious';
-import { useSafeState } from '../useSafeState/useSafeState';
 import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
 import { useUpdateEffect } from '../useUpdateEffect/useUpdateEffect';
 import { NextState, resolveHookState } from '../util/resolveHookState';
@@ -157,7 +156,7 @@ export function useStorageValue<T>(
   });
 
   const isFirstMount = useFirstMountState();
-  const [state, setState] = useSafeState<T | null | undefined>(
+  const [state, setState] = useState<T | null | undefined>(
     initializeWithStorageValue && isFirstMount ? (methods.current.fetchVal() as T) : undefined
   );
   const prevState = usePrevious(state);


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

The current behavior has been described in #451. In short, using the `setValue` function provided by `useSessionStorageValue` and `useLocalStorageValue` on first mount could cause other instances of those hooks to get out of sync.

### What is the expected behavior?

Every instance of the `useSessionStorageValue` and `useLocalStorageValue` hooks should return the same value at all times.

### How does this PR fix the problem?
By using `useState` to store the value of the tracked key instead of `useSafeState`.

In the sandbox below, I have modified the `useSessionValue` hook in the above way. The example is the one provided in #451 , but this time the reported issue is not present.

[![Edit unruffled-dijkstra-kqnbjy](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/unruffled-dijkstra-kqnbjy?fontsize=14&hidenavigation=1&theme=dark)

Why does this work, you might ask? I do not know. I will have to digest this a bit more. 

I arrived at this solution from the simple notion that the `state` variable is what gets out of sync. I then started going through everything that affected `state`. I went through many things, but finally I noticed that `useSafeState` also "affects" `state` (in a sense that it is not the standard `useState` that I picture in my mind when I think about React state). I then tried switching it to
a traditional `useState`, which seemed to solve the issue.

### Checklist

- [X] Have you read [contribution guideline](https://github.com/react-hookz/CONTRIBUTING.md)?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Is there an existing issue for this PR?
  -  #451 
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated to match the changes in the PR?
- [X] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?