### PR TITLE
Add docs for the new API of useSessionStorageValue and useLocalStorageValue

### DIFF
--- a/src/useLocalStorageValue/__docs__/example.stories.tsx
+++ b/src/useLocalStorageValue/__docs__/example.stories.tsx
@@ -34,7 +34,7 @@ export const Example: React.FC<ExampleProps> = ({
         onChange={(ev) => {
           lsVal.set(ev.currentTarget.value);
         }}
-      />{' '}
+      />
       <button onClick={lsVal.remove}>remove storage value</button>
     </div>
   );

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -1,6 +1,6 @@
-import { Example } from './example.stories';
-import { ImportPath } from '../../__docs__/ImportPath';
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Example } from './example.stories'
+import { ImportPath } from '../../__docs__/ImportPath'
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
 
 <Meta title="Side-effect/useLocalStorageValue" component={Example} />
 
@@ -13,16 +13,14 @@ Manages a single LocalStorage key.
 - Synchronized between all hooks on the page with the same key.
 - SSR compatible.
 
-> **_This hook provides stable API, meaning returned methods does not change between renders_**
-
-> This hook uses `useSafeState` underneath, so it is safe to use its `setState` in async hooks.
+> **_This hook provides stable API, meaning the returned methods do not change between renders._**
 
 > Does not allow usage of `null` value, since JSON allows serializing `null` values - it would be
 > impossible to separate null value fom 'no such value' API result which is also `null`.
 
-> While using SSR, to avoid hydration mismatch, consider setting `initializeWithStorageValue` option
-> to `false`, this will yield `undefined` state on first render and defer value fetch till effects
-> execution stage.
+> While using SSR, to avoid hydration mismatch, consider setting `initializeWithValue` option
+> to `false` - this will yield `undefined` state on first render and defer value fetching until effects
+> are executed.
 
 #### Example
 
@@ -50,23 +48,20 @@ function useLocalStorageValue<T>(
 
 <ImportPath />
 
+
 #### Arguments
 
 - **key** _`string`_ - LocalStorage key to manage.
-- **defaultValue** _`T | null`_ _(default: null)_ - Default value to return in case key not
-  presented in LocalStorage.
 - **options** _`object`_ - Hook options:
-  - **isolated** _`boolean`_ _(default: false)_ - Disable synchronisation with other hook instances
-    with the same key on the same page.
-  - **handleStorageEvent** _`boolean`_ _(default: true)_ - Subscribe to window's `storage` event.
-  - **storeDefaultValue** _`boolean`_ _(default: false)_ - store default value.
-  - **initializeWithStorageValue** _`boolean`_ _(default: true)_ - fetch storage value on first
-    render. If set to `false` will make hook to yield `undefined` state on first render and defer
-    value fetch till effects execution stage.
+  - **defaultValue** _`T | null`_ - Value to return if `key` is not present in LocalStorage.
+  - **initializeWithValue** _`boolean`_ _(default: true)_ - Fetch storage value on first render. If
+    set to `false` will make the hook yield `undefined` on first render and defer fetching of the
+    value until effects are executed.
 
 #### Return
 
-0. **state** - LocalStorage item value or default value in case of item absence.
-1. **setValue** - Method to set new item value.
-2. **removeValue** - Method to remove item from storage.
-3. **fetchValue** - Method to pull value from localStorage.
+0. **value** - LocalStorage value of the given `key` argument or `defaultValue`, if the key was not
+present.
+1. **set** - Method to set a new value for the managed `key`.
+2. **remove** - Method to remove the current value of `key`.
+3. **fetch** - Method to manually retrieve the value of `key`.

--- a/src/useSessionStorageValue/__docs__/example.stories.tsx
+++ b/src/useSessionStorageValue/__docs__/example.stories.tsx
@@ -31,7 +31,7 @@ export const Example: React.FC<ExampleProps> = ({
         onChange={(ev) => {
           ssVal.set(ev.currentTarget.value);
         }}
-      />{' '}
+      />
       <button onClick={ssVal.remove}>remove storage value</button>
     </div>
   );

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -1,6 +1,6 @@
-import { Example } from './example.stories';
-import { ImportPath } from '../../__docs__/ImportPath';
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Example } from './example.stories'
+import { ImportPath } from '../../__docs__/ImportPath'
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
 
 <Meta title="Side-effect/useSessionStorageValue" component={Example} />
 
@@ -13,16 +13,14 @@ Manages a single SessionStorage key.
 - Synchronized between all hooks on the page with the same key.
 - SSR compatible.
 
-> **_This hook provides stable API, meaning returned methods does not change between renders_**
-
-> This hook uses `useSafeState` underneath, so it is safe to use its `setState` in async hooks.
+> **_This hook provides stable API, meaning the returned methods do not change between renders._**
 
 > Does not allow usage of `null` value, since JSON allows serializing `null` values - it would be
 > impossible to separate null value fom 'no such value' API result which is also `null`.
 
-> While using SSR, to avoid hydration mismatch, consider setting `initializeWithStorageValue` option
-> to `false`, this will yield `undefined` state on first render and defer value fetch till effects
-> execution stage.
+> While using SSR, to avoid hydration mismatch, consider setting `initializeWithValue` option
+> to `false` - this will yield `undefined` state on first render and defer value fetching until effects
+> are executed.
 
 #### Example
 
@@ -53,20 +51,16 @@ function useSessionStorageValue<T>(
 #### Arguments
 
 - **key** _`string`_ - SessionStorage key to manage.
-- **defaultValue** _`T | null`_ _(default: null)_ - Default value to return in case key not
-  presented in SessionStorage.
 - **options** _`object`_ - Hook options:
-  - **isolated** _`boolean`_ _(default: false)_ - Disable synchronisation with other hook instances
-    with the same key on same page.
-  - **handleStorageEvent** _`boolean`_ _(default: true)_ - Subscribe to window's `storage` event.
-  - **storeDefaultValue** _`boolean`_ _(default: false)_ - store default value.
-  - **initializeWithStorageValue** _`boolean`_ _(default: true)_ - fetch storage value on first
-    render. If set to `false` will make hook to yield `undefined` state on first render and defer
-    value fetch till effects execution stage.
+  - **defaultValue** _`T | null`_ - Value to return if `key` is not present in SessionStorage.
+  - **initializeWithValue** _`boolean`_ _(default: true)_ - Fetch storage value on first render. If
+    set to `false` will make the hook yield `undefined` on first render and defer fetching of the
+    value until effects are executed.
 
 #### Return
 
-0. **state** - SessionStorage item value or default value in case of item absence.
-1. **setValue** - Method to set new item value.
-2. **removeValue** - Method to remove item from storage.
-3. **fetchValue** - Method to pull value from sessionStorage.
+0. **value** - SessionStorage value of the given `key` argument or `defaultValue`, if the key was not
+present.
+1. **set** - Method to set a new value for the managed `key`.
+2. **remove** - Method to remove the current value of `key`.
+3. **fetch** - Method to manually retrieve the value of `key`.

--- a/src/useSessionStorageValue/useSessionStorageValue.ts
+++ b/src/useSessionStorageValue/useSessionStorageValue.ts
@@ -5,14 +5,14 @@ import {
 } from '../useStorageValue/useStorageValue';
 import { isBrowser, noop } from '../util/const';
 
-let IS_LOCAL_STORAGE_AVAILABLE: boolean;
+let IS_SESSION_STORAGE_AVAILABLE: boolean;
 
 try {
-  IS_LOCAL_STORAGE_AVAILABLE = isBrowser && !!window.sessionStorage;
+  IS_SESSION_STORAGE_AVAILABLE = isBrowser && !!window.sessionStorage;
 } catch {
-  // no need to test this flag leads to noop behaviour
+  // no need to test as this flag leads to noop behaviour
   /* istanbul ignore next */
-  IS_LOCAL_STORAGE_AVAILABLE = false;
+  IS_SESSION_STORAGE_AVAILABLE = false;
 }
 
 type UseSessionStorageValue = <
@@ -27,7 +27,7 @@ type UseSessionStorageValue = <
 /**
  * Manages a single sessionStorage key.
  */
-export const useSessionStorageValue: UseSessionStorageValue = !IS_LOCAL_STORAGE_AVAILABLE
+export const useSessionStorageValue: UseSessionStorageValue = !IS_SESSION_STORAGE_AVAILABLE
   ? <
       Type,
       Default extends Type = Type,

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -95,7 +95,7 @@ export interface UseStorageValueOptions<T, InitializeWithValue extends boolean |
   /**
    * Whether to initialize state with storage value or initialize with `undefined` state.
    *
-   * @default false
+   * @default true
    */
   initializeWithValue?: InitializeWithValue;
 }


### PR DESCRIPTION
## What is the problem?

The API of `useStorageValue` has changed. The changes need to be reflected in the documentation of `useSessionStorageValue` and `useLocalStorageValue`.

## What changes does this PR make to fix the problem?

Modify the relevant pieces of the docs. Please make sure that I did not miss anything.

Also, do the current examples seem a bit weird to you? They don't really persist the values the user types into the inputs and you cannot see anything come up in storages. But I guess that is because the example is in an iframe (but don't the iframe and the docs page come from the same domain? Then the iframe should be able to access the parent's storages).

Relates to #960 
