### PR TITLE
fix: migration guide

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -163,7 +163,7 @@ Not implemented yet
 
 #### useWindowSize
 
-Not implemented yet
+Implemented as [useWindowSize](/docs/dom-usewindowsize--example)
 
 #### useMeasure
 


### PR DESCRIPTION
## What is the problem?

`useWindowSize` was listed as not implemented in the migration guide

## What changes does this PR make to fix the problem?

Migration guide now links to `useWindowSize` doc

