### PR TITLE
fix(useCustomCompareMemo): Correctly infer factory function return type

### DIFF
--- a/src/useCustomCompareMemo/__docs__/story.mdx
+++ b/src/useCustomCompareMemo/__docs__/story.mdx
@@ -22,11 +22,11 @@ export type DependenciesComparator<Deps extends DependencyList = DependencyList>
   b: Deps
 ) => boolean;
 
-function useCustomCompareMemo<Factory extends () => unknown, Deps extends DependencyList>(
-  factory: Factory,
+function useCustomCompareMemo<T, Deps extends DependencyList>(
+  factory: () => T,
   deps: Deps,
   comparator: DependenciesComparator<Deps>
-): ReturnType<Factory>;
+): T
 ```
 
 #### Importing

--- a/src/useCustomCompareMemo/useCustomCompareMemo.ts
+++ b/src/useCustomCompareMemo/useCustomCompareMemo.ts
@@ -10,11 +10,11 @@ import type { DependenciesComparator } from '../types';
  * @param comparator function to validate dependency changes
  * @returns useMemo result
  */
-export const useCustomCompareMemo = <Factory extends () => unknown, Deps extends DependencyList>(
-  factory: Factory,
+export const useCustomCompareMemo = <T, Deps extends DependencyList>(
+  factory: () => T,
   deps: Deps,
   comparator: DependenciesComparator<Deps>
-) => {
+): T => {
   const dependencies = useRef<Deps>();
 
   if (dependencies.current === undefined || !comparator(dependencies.current, deps)) {
@@ -22,5 +22,5 @@ export const useCustomCompareMemo = <Factory extends () => unknown, Deps extends
   }
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- missing factory function
-  return useMemo(factory, dependencies.current);
+  return useMemo<T>(factory, dependencies.current);
 };


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

Described in #975.

### What is the expected behavior?

Described in #975.

### How does this PR fix the problem?

Change the type of the `useCustomCompareMemo` factory function to include a generic type parameter for the return type. This generic type is then passed to the underlying `useMemo`, guaranteeing correct return type.

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Is there an existing issue for this PR?
  - #975 
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated to match the changes in the PR?
- [X] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?
