### PR TITLE
Add Github link to docs, mention `react-use` next to `migration guide`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ import { useMountEffect } from '@react-hookz/web/esnext';
 
 ## Migrating from react-use
 
+`@react-hookz/web` was built as a [spiritual successor](https://github.com/streamich/react-use/issues/1974) of `react-use` by one of its former maintainers.
+
 Coming from `react-use`? Check out our
 [migration guide](https://react-hookz.github.io/web/?path=/docs/migrating-from-react-use--page).
 

--- a/src/__docs__/Introduction.story.mdx
+++ b/src/__docs__/Introduction.story.mdx
@@ -58,3 +58,8 @@ import { useMountEffect } from '@react-hookz/web/esm';
 // in case you want all the recent ES features
 import { useMountEffect } from '@react-hookz/web/esnext';
 ```
+
+## Migrating from react-use
+
+Coming from `react-use`? Check out our
+[migration guide](https://react-hookz.github.io/web/?path=/docs/migrating-from-react-use--page).

--- a/src/__docs__/Introduction.story.mdx
+++ b/src/__docs__/Introduction.story.mdx
@@ -14,7 +14,7 @@ import { Meta } from '@storybook/addon-docs';
 [![Types](https://flat.badgen.net/npm/types/@react-hookz/web)](https://www.npmjs.com/package/@react-hookz/web)
 [![Tree Shaking](https://flat.badgen.net/bundlephobia/tree-shaking/@react-hookz/web)](https://bundlephobia.com/result?p=@react-hookz/web)
 
-× **[DOCS](https://react-hookz.github.io/web/)** × **[DISCORD](https://discord.gg/Fjwphtu65f)** ×
+× **[GITHUB](https://github.com/react-hookz/web)** × **[DISCORD](https://discord.gg/Fjwphtu65f)** ×
 **[CHANGELOG](https://github.com/react-hookz/web/blob/master/CHANGELOG.md)** ×
 
 </div>
@@ -35,7 +35,7 @@ yarn add @react-hookz/web
 ```
 
 As hooks was introduced to the world in React 16.8, `@react-hookz/web` requires - you guessed it -
-`react` and `react-dom` 16.8+.  
+`react` and `react-dom` 16.8+.
 Also, as React does not support IE, `@react-hookz/web` does not do so either. You'll have to
 transpile your `node-modules` in order to run in IE.
 

--- a/src/__docs__/Introduction.story.mdx
+++ b/src/__docs__/Introduction.story.mdx
@@ -61,5 +61,7 @@ import { useMountEffect } from '@react-hookz/web/esnext';
 
 ## Migrating from react-use
 
+`@react-hookz/web` was built as a [spiritual successor](https://github.com/streamich/react-use/issues/1974) of `react-use` by one of its former maintainers.
+
 Coming from `react-use`? Check out our
 [migration guide](https://react-hookz.github.io/web/?path=/docs/migrating-from-react-use--page).


### PR DESCRIPTION
## What is the problem?

I wanted a link to Github from the docs, as I'd often find myself going from one to the other.

I also wanted to make it clearer that our intention is to be a spiritual successor of react-use, as someone in Discord pointed out

## What changes does this PR make to fix the problem?

## Checklist

- [ ] The link to Github on the docs looks good
- [ ] The wording about being a spiritual successor to react-use looks good
