### PR TITLE
docs(migrating-from-react-use.story.mdx): Add mention about not imple…

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -383,7 +383,13 @@ execute();
 
 #### useBeforeUnload
 
-Not implemented yet
+No plans to implement. Use [useEventListener](/docs/dom-useeventlistener--example) instead:
+
+```javascript
+useEventListener(window, 'beforeunload', () => {
+  /* do your stuff here */
+});
+```
 
 #### useCookie
 


### PR DESCRIPTION
## What is the problem?

`useBeforeUnload` will not be migrated from react-use since we already have implemented `useEventListener`.

## What changes does this PR make to fix the problem?

Add a mention about this to the migration guide.

## Checklist

- [X] Is there an existing issue for this PR?
  - #33 
