### PR TITLE
Fix `initializeWithValue` default not respected, fix docs and tests

### DIFF
--- a/src/useLocalStorageValue/__docs__/example.stories.tsx
+++ b/src/useLocalStorageValue/__docs__/example.stories.tsx
@@ -18,7 +18,6 @@ export const Example: React.FC<ExampleProps> = ({
 }) => {
   const lsVal = useLocalStorageValue(key, {
     defaultValue,
-    initializeWithValue: true,
   });
 
   return (

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -53,7 +53,7 @@ function useLocalStorageValue<T>(
 - **key** _`string`_ - LocalStorage key to manage.
 - **options** _`object`_ - Hook options:
   - **defaultValue** _`T | null`_ - Value to return if `key` is not present in LocalStorage.
-  - **initializeWithValue** _`boolean`_ _(default: false)_ - Fetch storage value on first render. If
+  - **initializeWithValue** _`boolean`_ _(default: true)_ - Fetch storage value on first render. If
     set to `false` will make the hook yield `undefined` on first render and defer fetching of the
     value until effects are executed.
 

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -53,7 +53,7 @@ function useLocalStorageValue<T>(
 - **key** _`string`_ - LocalStorage key to manage.
 - **options** _`object`_ - Hook options:
   - **defaultValue** _`T | null`_ - Value to return if `key` is not present in LocalStorage.
-  - **initializeWithValue** _`boolean`_ _(default: true)_ - Fetch storage value on first render. If
+  - **initializeWithValue** _`boolean`_ _(default: false)_ - Fetch storage value on first render. If
     set to `false` will make the hook yield `undefined` on first render and defer fetching of the
     value until effects are executed.
 

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -1,6 +1,6 @@
-import { Example } from './example.stories'
-import { ImportPath } from '../../__docs__/ImportPath'
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+import {Example} from './example.stories'
+import {ImportPath} from '../../__docs__/ImportPath'
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs'
 
 <Meta title="Side-effect/useLocalStorageValue" component={Example} />
 
@@ -18,8 +18,9 @@ Manages a single LocalStorage key.
 > Does not allow usage of `null` value, since JSON allows serializing `null` values - it would be
 > impossible to separate null value fom 'no such value' API result which is also `null`.
 
-> Due to support of SSR this hook returns undefined on first render even if value is there, to avoid
-> this behavior set the `initializeWithValue` option to true.
+> If you are doing SSR, set `initializeWithValue` to `false` in order for this hook to return
+> `undefined` on first render. The LocalStorage value will be fetched client-side when effects
+> are executed.
 
 #### Example
 

--- a/src/useSessionStorageValue/__docs__/example.stories.tsx
+++ b/src/useSessionStorageValue/__docs__/example.stories.tsx
@@ -16,7 +16,7 @@ export const Example: React.FC<ExampleProps> = ({
   key = 'react-hookz-ss-test',
   defaultValue = '@react-hookz is awesome',
 }) => {
-  const ssVal = useSessionStorageValue(key, { defaultValue, initializeWithValue: true });
+  const ssVal = useSessionStorageValue(key, { defaultValue });
 
   return (
     <div>

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -1,6 +1,6 @@
-import { Example } from './example.stories'
-import { ImportPath } from '../../__docs__/ImportPath'
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs'
+import {Example} from './example.stories'
+import {ImportPath} from '../../__docs__/ImportPath'
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs'
 
 <Meta title="Side-effect/useSessionStorageValue" component={Example} />
 
@@ -18,8 +18,9 @@ Manages a single SessionStorage key.
 > Does not allow usage of `null` value, since JSON allows serializing `null` values - it would be
 > impossible to separate null value fom 'no such value' API result which is also `null`.
 
-> Due to support of SSR this hook returns undefined on first render even if value is there, to avoid
-> this behavior set the `initializeWithValue` option to true.
+> If you are doing SSR, set `initializeWithValue` to `false` in order for this hook to return
+> `undefined` on first render. The SessionStorage value will be fetched client-side when effects
+> are executed.
 
 #### Example
 

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -52,7 +52,7 @@ function useSessionStorageValue<T>(
 - **key** _`string`_ - SessionStorage key to manage.
 - **options** _`object`_ - Hook options:
   - **defaultValue** _`T | null`_ - Value to return if `key` is not present in SessionStorage.
-  - **initializeWithValue** _`boolean`_ _(default: false)_ - Fetch storage value on first render. If
+  - **initializeWithValue** _`boolean`_ _(default: true)_ - Fetch storage value on first render. If
     set to `false` will make the hook yield `undefined` on first render and defer fetching of the
     value until effects are executed.
 

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -52,7 +52,7 @@ function useSessionStorageValue<T>(
 - **key** _`string`_ - SessionStorage key to manage.
 - **options** _`object`_ - Hook options:
   - **defaultValue** _`T | null`_ - Value to return if `key` is not present in SessionStorage.
-  - **initializeWithValue** _`boolean`_ _(default: true)_ - Fetch storage value on first render. If
+  - **initializeWithValue** _`boolean`_ _(default: false)_ - Fetch storage value on first render. If
     set to `false` will make the hook yield `undefined` on first render and defer fetching of the
     value until effects are executed.
 

--- a/src/useStorageValue/__tests__/ssr.ts
+++ b/src/useStorageValue/__tests__/ssr.ts
@@ -12,58 +12,71 @@ describe('useStorageValue', () => {
     expect(result.error).toBeUndefined();
   });
 
-  it('should not fetch value from storage on init', () => {
-    const storage = newStorage();
-    const { result } = renderHook(() => useStorageValue(storage, 'foo'));
+  describe('if initializeWithValue set to false', () => {
+    it('should not fetch value from storage on init', () => {
+      const storage = newStorage();
+      const { result } = renderHook(() =>
+        useStorageValue(storage, 'foo', { initializeWithValue: false })
+      );
 
-    expect(result.current.value).toBe(undefined);
-    expect(storage.getItem).not.toHaveBeenCalled();
-  });
-
-  it('should not fetch value from storage on .fetch() call', () => {
-    const storage = newStorage();
-    const { result } = renderHook(() => useStorageValue(storage, 'foo'));
-
-    expect(result.current.value).toBe(undefined);
-    act(() => {
-      result.current.fetch();
+      expect(result.current.value).toBe(undefined);
+      expect(storage.getItem).not.toHaveBeenCalled();
     });
-    expect(result.current.value).toBe(undefined);
-    expect(storage.getItem).not.toHaveBeenCalled();
-  });
 
-  it('should not set storage value on .set() call', () => {
-    const storage = newStorage();
-    const { result } = renderHook(() => useStorageValue<string>(storage, 'foo'));
+    it('should not fetch value from storage on .fetch() call', () => {
+      const storage = newStorage();
+      const { result } = renderHook(() =>
+        useStorageValue(storage, 'foo', { initializeWithValue: false })
+      );
 
-    expect(result.current.value).toBe(undefined);
-    act(() => {
-      result.current.set('bar');
+      expect(result.current.value).toBe(undefined);
+      act(() => {
+        result.current.fetch();
+      });
+      expect(result.current.value).toBe(undefined);
+      expect(storage.getItem).not.toHaveBeenCalled();
     });
-    expect(result.current.value).toBe(undefined);
-    expect(storage.setItem).not.toHaveBeenCalled();
-  });
 
-  it('should not call storage`s removeItem on .remove() call', () => {
-    const storage = newStorage();
-    const { result } = renderHook(() => useStorageValue<string>(storage, 'foo'));
+    it('should not set storage value on .set() call', () => {
+      const storage = newStorage();
+      const { result } = renderHook(() =>
+        useStorageValue<string>(storage, 'foo', { initializeWithValue: false })
+      );
 
-    act(() => {
-      result.current.remove();
+      expect(result.current.value).toBe(undefined);
+      act(() => {
+        result.current.set('bar');
+      });
+      expect(result.current.value).toBe(undefined);
+      expect(storage.setItem).not.toHaveBeenCalled();
     });
-    expect(storage.removeItem).not.toHaveBeenCalled();
-  });
 
-  it('should not set state to default value on item remove', () => {
-    const storage = newStorage(() => '"bar"');
-    const { result } = renderHook(() =>
-      useStorageValue<string>(storage, 'foo', { defaultValue: 'default value' })
-    );
+    it('should not call storage`s removeItem on .remove() call', () => {
+      const storage = newStorage();
+      const { result } = renderHook(() =>
+        useStorageValue<string>(storage, 'foo', { initializeWithValue: false })
+      );
 
-    expect(result.current.value).toBe(undefined);
-    act(() => {
-      result.current.remove();
+      act(() => {
+        result.current.remove();
+      });
+      expect(storage.removeItem).not.toHaveBeenCalled();
     });
-    expect(result.current.value).toBe(undefined);
+
+    it('should not set state to default value on item remove', () => {
+      const storage = newStorage(() => '"bar"');
+      const { result } = renderHook(() =>
+        useStorageValue<string>(storage, 'foo', {
+          defaultValue: 'default value',
+          initializeWithValue: false,
+        })
+      );
+
+      expect(result.current.value).toBe(undefined);
+      act(() => {
+        result.current.remove();
+      });
+      expect(result.current.value).toBe(undefined);
+    });
   });
 });

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -120,9 +120,9 @@ export interface UseStorageValueResult<
   fetch: () => void;
 }
 
-const DEFAULT_OPTIONS: UseStorageValueOptions<null, false> = {
+const DEFAULT_OPTIONS: UseStorageValueOptions<null, true> = {
   defaultValue: null,
-  initializeWithValue: false,
+  initializeWithValue: true,
 };
 
 export function useStorageValue<

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -156,7 +156,9 @@ export function useStorageValue<
 
   const isFirstMount = useFirstMountState();
   const [state, setState] = useState<Type | null | undefined>(
-    options?.initializeWithValue && isFirstMount ? storageActions.current.fetch() : undefined
+    optionsRef.current?.initializeWithValue && isFirstMount
+      ? storageActions.current.fetch()
+      : undefined
   );
   const stateRef = useSyncedRef(state);
 
@@ -172,7 +174,7 @@ export function useStorageValue<
   }, [key]);
 
   useEffect(() => {
-    if (!options?.initializeWithValue) {
+    if (!optionsRef.current.initializeWithValue) {
       stateActions.current.fetch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -120,9 +120,9 @@ export interface UseStorageValueResult<
   fetch: () => void;
 }
 
-const DEFAULT_OPTIONS: UseStorageValueOptions<null, true> = {
+const DEFAULT_OPTIONS: UseStorageValueOptions<null, false> = {
   defaultValue: null,
-  initializeWithValue: true,
+  initializeWithValue: false,
 };
 
 export function useStorageValue<


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

`initializeWithValue` default value is not respected. It is always read from user-given `options`, meaning that it is `undefined` (effectively `false`), if the user did not explicitly set it.

Reproduction steps are given in #1002 . It looks like `initializeWithValue` is `false` by default (which is what the bug report is about), but actually it's just that the default value of `true` is not respected.

Additionally, I noticed that the default value for `initializeWithValue` is set to `true`, which partly contradicts the documentation (in the top part of the docs of `useSessionStorageValue` and `useLocalStorageValue` `initializeWithValue` is said to be `false` by default, but in the description of the `options` argument it is said to be `true`) and the tests. After fixing `useStorageValue` to respect the default value of `initializeWithValue` it became necessary to set it to `false`, otherwise SSR tests would fail, as they should.

### What is the expected behavior?
The `initializeWithValue` default should be respected and it should be `false` by default.

### How does this PR fix the problem?

- Make sure the default value of `initializeWithValue` is used if it is not provided by the user.
- Set `initializeWithValue` to `false` by default.
  - Note, that this is not a breaking change, because previously it was already effectively `false`.

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Is there an existing issue for this PR?
  - #1002 
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated to match the changes in the PR?
- [X] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?
