### PR TITLE
fix(useStorageValue): make methods to be stable between renders

### DIFF
--- a/src/useStorageValue/__tests__/dom.ts
+++ b/src/useStorageValue/__tests__/dom.ts
@@ -13,6 +13,22 @@ describe('useStorageValue', () => {
     expect(result.error).toBeUndefined();
   });
 
+  it('should action methods should be stable between renders', () => {
+    const { result, rerender } = renderHook(() => useStorageValue(newStorage(), 'foo'));
+
+    rerender();
+    act(() => {
+      result.current.set('bar');
+    });
+    rerender();
+
+    type ResultType = typeof result.current;
+
+    expect((result.all[0] as ResultType).set).toBe(result.current.set);
+    expect((result.all[0] as ResultType).fetch).toBe(result.current.fetch);
+    expect((result.all[0] as ResultType).remove).toBe(result.current.remove);
+  });
+
   it('should fetch value from storage only on init', () => {
     const storage = newStorage((key) => `"${key}"`);
     const { result, rerender } = renderHook(() => useStorageValue(storage, 'foo'));

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -217,12 +217,21 @@ export function useStorageValue<
     },
   });
 
+  // make actions static so developers can pass methods further
+  const staticActions = useMemo(
+    () => ({
+      set: ((v) => actions.current.set(v)) as typeof actions.current.set,
+      remove: () => actions.current.delete(),
+      fetch: () => actions.current.fetch(),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
   return useMemo(
     () => ({
       value: state as UseStorageValueValue<Type, Default, Initialize>,
-      set: actions.current.set,
-      remove: actions.current.delete,
-      fetch: actions.current.fetch,
+      ...staticActions,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state]


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

`useStoageValue` methods are not stable between renders, after state change.

### What is the expected behavior?

Methods should not change between renders

### How does this PR fix the problem?

Wrap methods with `useMemo` and interpolate them into returned object.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #1014 
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
