### PR TITLE
docs(migrating-from-react-use): Add mention about not porting location-related hooks

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs'
+import {Meta} from '@storybook/addon-docs'
 
 <Meta title="Migrating from react-use" />
 
@@ -43,7 +43,8 @@ Not implemented yet
 
 #### useHash
 
-Not implemented yet
+Location-related hooks will not be implemented. Instead, consider using one of the various routing
+libraries available.
 
 #### useIdle
 
@@ -91,11 +92,13 @@ See [useKeyboardEvent](https://react-hookz.github.io/web/?path=/docs/dom-usekeyb
 
 #### useLocation
 
-Not implemented yet
+Location-related hooks will not be implemented. Instead, consider using one of the various routing
+libraries available.
 
 #### useSearchParam
 
-Not implemented yet
+Location-related hooks will not be implemented. Instead, consider using one of the various routing
+libraries available.
 
 #### useLongPress
 


### PR DESCRIPTION
## What is the problem?

In #33 it was decided that location-related hooks will not be ported, since those are already provided by the various routing libraries available.

## What changes does this PR make to fix the problem?

Add a mention about this decision to the migration guide.

## Checklist

- [x] Is there an existing issue for this PR?
  - #33 

Closes #992 
