### PR TITLE
Fix typos and improve language in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,12 @@ If you are contributing for the first time, we recommend reading this
 
 1. Fork the main repo
 2. Clone the repo to your computer (add `--depth=1` to `git clone` command to save time)
-3. Change folder to the just cloned repo: `cd ./web`
+3. Change folder to the cloned repo: `cd ./web`
 4. Install dependencies: `yarn`
 5. Make sure everything builds and tests: `yarn build && yarn test`
 6. Create a branch for your PR: `git checkout -b pr/my-awesome-hook`
    - if you are adding a new hook, name the branch based on the hook: `pr/useUpdateEffect`
-   - if your change fixes an issue, name the branch based on the issue ID: `pr/fix-12345`
+   - if your change fixes an issue, name the branch based on the issue number: `pr/fix-12345`
 7. Follow the directions below:
 
 > **Tip:** to keep your `master` branch pointing to the original repo's `master` (instead of your
@@ -36,7 +36,7 @@ If you are contributing for the first time, we recommend reading this
    - The file should be named after the hook and placed in a subdirectory also named after the hook.
    - The hook should have return types explicitly defined.
    - The hook should have a JSDoc comment containing a description of the hook and an overview of its arguments.
-   - The hook should be exported by name, not default exported.
+   - The hook should be exported by name, not by default.
    - If the hook has custom types in its parameters or return values, they should be exported as well.
    - Types and interfaces should not have prefixes like `I` or `T` (currently some types like this
      still exists for compatibility reasons, but they will be removed in the future).
@@ -44,7 +44,7 @@ If you are contributing for the first time, we recommend reading this
    - If the hook is stateful and exposes `setState` method, or is has async callbacks (that can
      theoretically be resolved after component unmount), it should use `useSafeState` instead of
      `useState`.
-   - If you reuse hooks from this library, import them as `import { useSafeState } from '../useSafeState/useSafeState';` instead of
+   - If your hook reuses other @react-hookz/web hooks, import them as `import { useSafeState } from '../useSafeState/useSafeState';` instead of
      `import { useSafeState } from '..';`
 2. Re-export the hook implementation and all its custom types in `src/index.ts`.
 3. Fully test your hook. The tests should include tests for both DOM and SSR environments.
@@ -61,14 +61,14 @@ If you are contributing for the first time, we recommend reading this
      For example: `src/useFirstMountState/__docs__/story.mdx`.
    - Docs are built with Storybook. You can run `yarn storybook:watch` to preview your work.
    - Write a short example demonstrating your hook in `example.stories.tsx` within the `__docs__` folder.
-     (If the filename misses the `.stories.tsx` part, Storybook can't find your example.)
+     (If the filename misses the `.stories.tsx` part, Storybook won't find your example.)
      For example: `src/useFirstMountState/__docs__/example.stories.tsx`.
    - Docs are written in MDX format.
      [Read more about storybook docs](https://storybook.js.org/docs/react/writing-docs/introduction).
 5. Add a summary of the hook and a link to the docs to `README.md`.
 6. After all the above steps are done, run `yarn lint:fix` to ensure that everything is styled by our
    standards.
-7. Command `yarn new-hook myAwesomeHook` will help you to create a proper file structure for the new hook.
+7. `yarn new-hook myAwesomeHook` will help you to create a proper file structure for the new hook.
 
 ## Committing
 
@@ -76,7 +76,7 @@ If you are contributing for the first time, we recommend reading this
 
 This repo uses [semantic-release](https://github.com/semantic-release/semantic-release) and
 [conventional commit messages](https://conventionalcommits.org) so prefix your commits with `fix:`,
-`feat:`, etc., if you want your changes to appear in the
+`feat:`, etc., so that your changes appear in the
 [release notes](https://github.com/react-hookz/web/blob/master/CHANGELOG.md).
 
 Also, there is a script that helps you to properly format commit messages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,24 @@
 # Contributing
 
-First of all, thanks for being willing to contribute to `@react-hookz`, the collective creating and
-using this library appreciates that.
+First of all, thanks for contributing to `@react-hookz`! The collective developing and
+using this library appreciates your efforts.
 
-If you are contributing for the first time - we would recommend reading
-[First Contributions](https://github.com/firstcontributions/first-contributions) guide first.
+If you are contributing for the first time, we recommend reading this
+[First Contributions guide](https://github.com/firstcontributions/first-contributions) first.
 
 ## Project setup
 
 1. Fork the main repo
-2. Clone repo to your computer (add `--depth=1` to `git clone` command to save time)
-3. Change folder to just cloned repo: `cd ./web`
+2. Clone the repo to your computer (add `--depth=1` to `git clone` command to save time)
+3. Change folder to the just cloned repo: `cd ./web`
 4. Install dependencies: `yarn`
 5. Make sure everything builds and tests: `yarn build && yarn test`
-6. Create the branch for your PR, like: `git checkout -b pr/my-awesome-hook`
-   - in case you are adding a new hook - it is better to name your branch by the hook:
-     `pr/useUpdateEffect`
-   - in case your change fixes an issue - it is better to name branch by the issue id:
-     `pr/fix-12345`
-7. Follow the directions below
+6. Create a branch for your PR: `git checkout -b pr/my-awesome-hook`
+   - if you are adding a new hook, name the branch based on the hook: `pr/useUpdateEffect`
+   - if your change fixes an issue, name the branch based on the issue ID: `pr/fix-12345`
+7. Follow the directions below:
 
-> **Tip:** to keep your `master` branch pointing at the original repo's `master` (instead of your
+> **Tip:** to keep your `master` branch pointing to the original repo's `master` (instead of your
 > fork's `master`) do this:
 >
 > ```shell
@@ -29,51 +27,48 @@ If you are contributing for the first time - we would recommend reading
 > git branch --set-upstream-to=upstream/master master
 > ```
 >
-> After running these commands you'll be able to easily pull changes from the original repository by
+> After running these commands you'll be able to easily pull changes from the original repository with
 > `git pull`.
 
 ## Development
 
-1. Implement the hook in `src` folder.
-   - File should be named after the hook and placed in subdirectory also named after the hook.
-   - Hook should have return types explicitly defined.
-   - Hook should have JSDoc containing hook description and an overview of its arguments.
-   - Hook should be exported by name, not default exported.
-   - In case hook has some custom types as arguments or return values - it should also be exported.
-   - Types and interfaces should not have prefixes like `I` or `T` (it is only left in existing code
-     for compatibility reasons and will be removed).
-   - Hook should be developed with SSR in mind.
-   - In case hook is stateful and exposes `setState` method, or is has async callbacks (that can
+1. Implement the hook in the `src` folder.
+   - The file should be named after the hook and placed in a subdirectory also named after the hook.
+   - The hook should have return types explicitly defined.
+   - The hook should have a JSDoc comment containing a description of the hook and an overview of its arguments.
+   - The hook should be exported by name, not default exported.
+   - If the hook has custom types in its parameters or return values, they should be exported as well.
+   - Types and interfaces should not have prefixes like `I` or `T` (currently some types like this
+     still exists for compatibility reasons, but they will be removed in the future).
+   - The hook should be developed with SSR in mind.
+   - If the hook is stateful and exposes `setState` method, or is has async callbacks (that can
      theoretically be resolved after component unmount), it should use `useSafeState` instead of
      `useState`.
-   - In case of hooks reuse, import them as `import { useSafeState } from '../useSafeState/useSafeState';` instead of
+   - If you reuse hooks from this library, import them as `import { useSafeState } from '../useSafeState/useSafeState';` instead of
      `import { useSafeState } from '..';`
-2. Reexport hook implementation and all custom types in `src/index.ts`.
-   - Custom types should be also reexported.
-3. Write complete tests for your hook, tests should consist of both DOM and SSR parts.
-   - Hook's test should be placed in `__tests__` sub-folder, near the source file, `dom.ts` for DOM
-     environment, `ssr.ts` for SSR environment.  
-     4ex: `src/useFirstMountState/__tests__/dom.ts` and `src/useFirstMountState/__tests__/ssr.ts`.
-   - Ideally your hook should have 100% test coverage. For cases where that is impossible, you
-     should comment above the code exactly why it is impossible to have 100% coverage.
+2. Re-export the hook implementation and all its custom types in `src/index.ts`.
+3. Fully test your hook. The tests should include tests for both DOM and SSR environments.
+   - Hook's tests should be placed in `__tests__` subdirectory, next to the source file - `dom.ts` for DOM
+     environment, `ssr.ts` for SSR environment.
+     For example: `src/useFirstMountState/__tests__/dom.ts` and `src/useFirstMountState/__tests__/ssr.ts`.
+   - Ideally, your hook should have 100% test coverage. If that is impossible, you should leave a comment
+     in the code describing why.
    - Each hook should have at least 'should be defined' and 'should render' tests in `SSR`
      environment.
    - All utility functions should also be tested.
 4. Write docs for your hook.
    - Docs should be placed in `__docs__` sub-folder, near the source file.  
-     4ex: `src/useFirstMountState/__docs__/story.mdx`.
-   - Docs are built with storybook, to help you during writing docs - start webserver with
-     `yarn storybook:watch`.
-   - Components representing hook functionality should be placed in `example.stories.tsx` within
-     `__docs__` folder. In case file name will be missing `.stories.tsx` part - code preview won't
-     work.  
-     4ex: `src/useFirstMountState/__docs__/example.stories.tsx`.
-   - Preferred format to write the docs is MDX.
+     For example: `src/useFirstMountState/__docs__/story.mdx`.
+   - Docs are built with Storybook. You can run `yarn storybook:watch` to preview your work.
+   - Write a short example demonstrating your hook in `example.stories.tsx` within the `__docs__` folder.
+     (If the filename misses the `.stories.tsx` part, Storybook can't find your example.)
+     For example: `src/useFirstMountState/__docs__/example.stories.tsx`.
+   - Docs are written in MDX format.
      [Read more about storybook docs](https://storybook.js.org/docs/react/writing-docs/introduction).
-5. Add docs link and hook summary to the `README.md`.
-6. After all above steps are done - run `yarn lint:fix` and ensure that everything is styled by our
+5. Add a summary of the hook and a link to the docs to `README.md`.
+6. After all the above steps are done, run `yarn lint:fix` to ensure that everything is styled by our
    standards.
-7. Command `yarn new-hook myAwesomeHook` will help you create proper file structure for new hook.
+7. Command `yarn new-hook myAwesomeHook` will help you to create a proper file structure for the new hook.
 
 ## Committing
 
@@ -81,21 +76,21 @@ If you are contributing for the first time - we would recommend reading
 
 This repo uses [semantic-release](https://github.com/semantic-release/semantic-release) and
 [conventional commit messages](https://conventionalcommits.org) so prefix your commits with `fix:`,
-`feat:`, etc., if you want your changes to appear in
+`feat:`, etc., if you want your changes to appear in the
 [release notes](https://github.com/react-hookz/web/blob/master/CHANGELOG.md).
 
-Also, there is a script that helps to properly format commit message:
+Also, there is a script that helps you to properly format commit messages:
 
 ```shell
 git add .
 yarn commit
 ```
 
-It will guide you through several prompts that will ease filling non-obvious and easy-to-forget
-parts.
+The script guides you through several prompts that help you with writing a good commit message,
+including many non-obvious and easy-to-forget parts.
 
 ### Git hooks
 
-There are git hooks set up with this project that are automatically enabled when you install
-dependencies. These hooks automatically test and validate your code and commit message. In most
-cases disabling these hooks is not recommended.
+This project includes Git hooks that are automatically enabled when you install the dependencies.
+These hooks automatically test and validate your code and commit messages before each commit. In
+most cases disabling these hooks is not recommended.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Coming from `react-use`? Check out our
   - [**`useRenderCount`**](https://react-hookz.github.io/web/?path=/docs/state-userendercount--example) —
     Tracks component's render count including first render.
   - [**`useSafeState`**](https://react-hookz.github.io/web/?path=/docs/state-usesafestate--page) —
-    Like `useState`, but its state setter is guarded against settings the state of an unmounted component.
+    Like `useState`, but its state setter is guarded against setting the state of an unmounted component.
   - [**`useSet`**](https://react-hookz.github.io/web/?path=/docs/state-useset--example) — Tracks the
     state of a `Set`.
   - [**`useToggle`**](https://react-hookz.github.io/web/?path=/docs/state-usetoggle--example) — Like
@@ -185,7 +185,7 @@ Coming from `react-use`? Check out our
     — Observe changes in the intersection of a target element with an ancestor element or with the
     viewport.
   - [**`useMeasure`**](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure--example) —
-    Uses `ResizeObserver` to track element's dimensions and to re-render the component when they change.
+    Uses `ResizeObserver` to track an element's dimensions and to re-render the component when they change.
   - [**`useMediaQuery`**](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery--example)
     — Tracks the state of a CSS media query.
   - [**`useResizeObserver`**](https://react-hookz.github.io/web/?path=/docs/sensor-useresizeobserver--example)

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ transpile your `node-modules` in order to run in IE.
 This package provides three levels of compilation:
 
 1. **Main**, the `/cjs` folder — CommonJS modules, with ES5 lang level.
-2. **ESM**, the `/esm` folder — it is ES modules (browser compatible), with ES5 lang level.
-3. **ESNext**, the `/esnext` folder — it is ES modules (browser compatible), with ESNext lang level.
+2. **ESM**, the `/esm` folder — ES modules (browser compatible), with ES5 lang level.
+3. **ESNext**, the `/esnext` folder — ES modules (browser compatible), with ESNext lang level.
 
-So, if you need the `useMountEffect` hook, depending on your needs, you can import in three ways
+So, if you need the `useMountEffect` hook, depending on your needs, you can import it in three ways
 (there are actually more, but these are the three most common):
 
 ```ts
@@ -76,50 +76,50 @@ Coming from `react-use`? Check out our
 - #### Lifecycle
 
   - [**`useConditionalEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useconditionaleffect--example)
-    — Like `useEffect` but callback invoked only if conditions match predicate.
+    — Like `useEffect` but callback invoked only if given conditions match a given predicate.
   - [**`useCustomCompareEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usecustomcompareeffect--example)
-    — Like `useEffect` but uses provided comparator function to validate dependency changes.
+    — Like `useEffect` but uses a provided comparator function to validate dependency changes.
   - [**`useDebouncedEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usedebouncedeffect--example)
     — Like `useEffect`, but passed function is debounced.
   - [**`useDeepCompareEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usedeepcompareeffect--example)
     — Like `useEffect` but uses `@react-hookz/deep-equal` comparator function to validate deep
     dependency changes.
   - [**`useFirstMountState`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usefirstmountstate--example)
-    — Return boolean that is `true` only on first render.
+    — Returns a boolean that is `true` only on first render.
   - [**`useIntervalEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useintervaleffect--example)
-    — Like `setInterval` but in form of react hook.
+    — Like `setInterval` but in the form of a React hook.
   - [**`useIsMounted`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useismounted--example)
-    — Returns function that yields current mount state.
+    — Returns a function that yields current mount state.
   - [**`useIsomorphicLayoutEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useisomorphiclayouteffect--page)
-    — `useLayoutEffect` for browser with fallback to `useEffect` for SSR.
+    — Like `useLayoutEffect` but falls back to `useEffect` during SSR.
   - [**`useMountEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemounteffect--example)
-    — Run effect only when component first-mounted.
+    — Run an effect only when a component mounts.
   - [**`useRafEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRafEffect--example)
-    — Like `React.useEffect`, but effect is only run within animation frame.
+    — Like `useEffect`, but the effect is only run within an animation frame.
   - [**`useRerender`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usererender--example)
-    — Return callback that re-renders component.
+    — Returns a callback that re-renders the component.
   - [**`useThrottledEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usethrottledeffect--example)
-    — Like `useEffect`, but passed function is throttled.
+    — Like `useEffect`, but the passed function is throttled.
   - [**`useTimeoutEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usetimeouteffect--example)
-    — Like `setTimeout`, but in the form of a react hook.
+    — Like `setTimeout`, but in the form of a React hook.
   - [**`useUnmountEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useunmounteffect--example)
-    — Run effect only when component unmounted.
+    — Run an effect only when a component unmounts.
   - [**`useUpdateEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useupdateeffect--example)
-    — Effect hook that ignores the first render (not invoked on mount).
+    — An effect hook that ignores the first render (not invoked on mount).
   - [**`useLifecycleLogger`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-uselifecycleLogger--example)
-    — This hook provides a console log when the component mounts, updates and unmounts.
+    — This hook provides logging when the component mounts, updates and unmounts.
 
 - #### State
 
   - [**`useControlledRerenderState`**](https://react-hookz.github.io/web/?path=/docs/state-usecontrolledrerenderstate--example)
-    — Like `React.useState`, but its state setter accepts extra argument, that allows to cancel
-    rerender.
+    — Like `useState`, but its state setter accepts an extra argument, that allows cancelling
+    renders.
   - [**`useCounter`**](https://react-hookz.github.io/web/?path=/docs/state-usecounter--example)
     — Tracks a numeric value and offers functions for manipulating it.
   - [**`useDebouncedState`**](https://react-hookz.github.io/web/?path=/docs/state-usedebouncedstate--example)
     — Like `useSafeState` but its state setter is debounced.
   - [**`useFunctionalState`**](https://react-hookz.github.io/web/?path=/docs/state-usefunctionalstate--page)
-    — Like `useState` but instead of raw state, state getter returned.
+    — Like `useState` but instead of raw state, a state getter function is returned.
   - [**`useList`**](https://react-hookz.github.io/web/?path=/docs/state-uselist--example)
     — Tracks a list and offers functions for manipulating it.
   - [**`useMap`**](https://react-hookz.github.io/web/?path=/docs/state-usemap--example) — Tracks the
@@ -129,49 +129,49 @@ Coming from `react-use`? Check out our
   - [**`usePrevious`**](https://react-hookz.github.io/web/?path=/docs/state-useprevious--example) —
     Returns the value passed to the hook on previous render.
   - [**`usePreviousDistinct`**](https://react-hookz.github.io/web/?path=/docs/state-usepreviousdistinct--example) —
-    Returns the most recent distinct value passed to the hook on previous render.
+    Returns the most recent distinct value passed to the hook on previous renders.
   - [**`useRafState`**](https://react-hookz.github.io/web/?path=/docs/state-userafstate--example) —
     Like `React.useState`, but state is only updated within animation frame.
   - [**`useRenderCount`**](https://react-hookz.github.io/web/?path=/docs/state-userendercount--example) —
     Tracks component's render count including first render.
   - [**`useSafeState`**](https://react-hookz.github.io/web/?path=/docs/state-usesafestate--page) —
-    Like `useState`, but its state setter is guarded against sets on unmounted component.
+    Like `useState`, but its state setter is guarded against settings the state of an unmounted component.
   - [**`useSet`**](https://react-hookz.github.io/web/?path=/docs/state-useset--example) — Tracks the
     state of a `Set`.
   - [**`useToggle`**](https://react-hookz.github.io/web/?path=/docs/state-usetoggle--example) — Like
-    `useState`, but can only become `true` or `false`.
+    `useState`, but can only be `true` or `false`.
   - [**`useThrottledState`**](https://react-hookz.github.io/web/?path=/docs/state-usethrottledstate--example)
     — Like `useSafeState` but its state setter is throttled.
   - [**`useValidator`**](https://react-hookz.github.io/web/?path=/docs/state-usevalidator--example)
-    — Performs validation when any of provided dependencies has changed.
+    — Performs validation when any of the provided dependencies change.
 
 - #### Navigator
 
   - [**`useNetworkState`**](https://react-hookz.github.io/web/?path=/docs/navigator-usenetworkstate--example)
-    — Tracks the state of browser's network connection.
+    — Tracks the state of the browser's network connection.
   - [**`useVibrate`**](https://react-hookz.github.io/web/?path=/docs/navigator-usevibrate--example)
     — Provides vibration feedback using the Vibration API.
   - [**`usePermission`**](https://react-hookz.github.io/web/?path=/docs/navigator-usepermission--example)
-    — Tracks a permission state.
+    — Tracks the state of a permission.
 
 - #### Miscellaneous
 
   - [**`useSyncedRef`**](https://react-hookz.github.io/web/?path=/docs/miscellaneous-usesyncedref--example)
-    — Like `useRef`, but it returns immutable ref that contains actual value.
+    — Like `useRef`, but it returns an immutable ref that contains the actual value.
   - [**`useCustomCompareMemo`**](https://react-hookz.github.io/web/?path=/docs/miscellaneous-useCustomCompareMemo--example)
-    — Like useMemo but uses provided comparator function to validate dependency changes.
+    — Like `useMemo` but uses provided comparator function to validate dependency changes.
   - [**`useDeepCompareMemo`**](https://react-hookz.github.io/web/?path=/docs/miscellaneous-useDeepCompareMemo--example)
     — Like `useMemo` but uses `@react-hookz/deep-equal` comparator function to validate deep
     dependency changes.
   - [**`useHookableRef`**](https://react-hookz.github.io/web/?path=/docs/miscellaneous-usehookableref--example)
-    — Like `useRef` but it is possible to define get and set handlers.
+    — Like `useRef` but it is possible to define handlers for getting and setting the value.
 
 - #### Side-effect
 
   - [**`useAsync`**](https://react-hookz.github.io/web/?path=/docs/side-effect-useasync--example) —
-    Executes provided async function and tracks its result and error.
+    Executes provided async function and tracks its results and errors.
   - [**`useAsyncAbortable`**](https://react-hookz.github.io/web/?path=/docs/side-effect-useasyncabortable--example)
-    — Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.
+    — Like `useAsync`, but also provides `AbortSignal` as first function argument to the async function.
   - [**`useCookieValue`**](https://react-hookz.github.io/web/?path=/docs/side-effect-usecookievalue--example)
     — Manages a single cookie.
   - [**`useLocalStorageValue`**](https://react-hookz.github.io/web/?path=/docs/side-effect-uselocalstoragevalue--example)
@@ -182,28 +182,28 @@ Coming from `react-use`? Check out our
 - #### Sensor
 
   - [**`useIntersectionObserver`**](https://react-hookz.github.io/web/?path=/docs/sensor-useintersectionobserver--example)
-    — Observe changes in the intersection of a target element with an ancestor element or with a
-    top-level document's viewport.
+    — Observe changes in the intersection of a target element with an ancestor element or with the
+    viewport.
   - [**`useMeasure`**](https://react-hookz.github.io/web/?path=/docs/sensor-usemeasure--example) —
-    Uses ResizeObserver to track element dimensions and re-render component when they change.
+    Uses `ResizeObserver` to track element's dimensions and to re-render the component when they change.
   - [**`useMediaQuery`**](https://react-hookz.github.io/web/?path=/docs/sensor-usemediaquery--example)
-    — Tracks the state of CSS media query.
+    — Tracks the state of a CSS media query.
   - [**`useResizeObserver`**](https://react-hookz.github.io/web/?path=/docs/sensor-useresizeobserver--example)
-    — Invokes a callback whenever ResizeObserver detects a change to target's size.
+    — Invokes a callback whenever `ResizeObserver` detects a change to the target's size.
   - [**`useScreenOrientation`**](https://react-hookz.github.io/web/?path=/docs/sensor-usescreenorientation--example)
-    — Checks if screen is in `portrait` or `landscape` orientation and automatically re-renders on
+    — Checks if the screen is in `portrait` or `landscape` orientation and automatically re-renders on
     orientation change.
 
 - #### Dom
 
   - [**`useClickOutside`**](https://react-hookz.github.io/web/?path=/docs/dom-useclickoutside--example)
-    — Triggers callback when user clicks outside the target element.
+    — Triggers a callback when user clicks outside the target element.
   - [**`useEventListener`**](https://react-hookz.github.io/web/?path=/docs/dom-useeventlistener--example)
-    — Subscribes an event listener to the target, and automatically unsubscribes it on unmount.
+    — Subscribes an event listener to the target and automatically unsubscribes it on unmount.
   - [**`useKeyboardEvent`**](https://react-hookz.github.io/web/?path=/docs/dom-usekeyboardevent--example)
-    — Executes callback when keyboard event occurred on target.
+    — Executes a callback whenever a keyboard event occurs on the target.
   - [**`useWindowSize`**](https://react-hookz.github.io/web/?path=/docs/dom-usewindowsize--example)
-    — Tracks window inner dimensions.
+    — Tracks the inner dimensions of the window.
 
 ## Contributors
 

--- a/src/__docs__/Introduction.story.mdx
+++ b/src/__docs__/Introduction.story.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
+import {Meta} from '@storybook/addon-docs';
 
 <Meta title="Home" />
 
@@ -44,10 +44,10 @@ transpile your `node-modules` in order to run in IE.
 This package provides three levels of compilation:
 
 1. **Main**, the `/cjs` folder — CommonJS modules, with ES5 lang level.
-2. **ESM**, the `/esm` folder — it is ES modules (browser compatible), with ES5 lang level.
-3. **ESNext**, the `/esnext` folder — it is ES modules (browser compatible), with ESNext lang level.
+2. **ESM**, the `/esm` folder — ES modules (browser compatible), with ES5 lang level.
+3. **ESNext**, the `/esnext` folder — ES modules (browser compatible), with ESNext lang level.
 
-So, if you need the `useMountEffect` hook, depending on your needs, you can import in three ways
+So, if you need the `useMountEffect` hook, depending on your needs, you can import it in three ways
 (there are actually more, but these are the three most common):
 
 ```ts

--- a/src/useAsync/__docs__/story.mdx
+++ b/src/useAsync/__docs__/story.mdx
@@ -49,7 +49,7 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
 
 2. **methods**
 
-   - **reset** _`() => void`_- Reset state to initial, when the async function hadn't been executed.
+   - **reset** _`() => void`_- Reset state to initial.
    - **execute** _`(...args: Args) => Promise<Result>`_- Execute the async function manually.
 
 2. **meta**

--- a/src/useAsync/__docs__/story.mdx
+++ b/src/useAsync/__docs__/story.mdx
@@ -1,15 +1,15 @@
-import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Example } from './example.stories';
-import { ImportPath } from '../../__docs__/ImportPath';
+import {Canvas, Meta, Story} from '@storybook/addon-docs';
+import {Example} from './example.stories';
+import {ImportPath} from '../../__docs__/ImportPath';
 
 <Meta title="Side-effect/useAsync" component={Example} />
 
 # useAsync
 
-Tracks result and error of provided async function and provides handles to execute and reset it.
+Tracks the result and errors of the provided async function and provides handles to control its execution.
 
-- Handles any async functions.
-- Safe - no worries about updating the state of unmounted component.
+- Handles any async function.
+- Safe - no worries about updating the state of an unmounted component.
 - Stable - returned methods do not change between renders.
 - Handles race conditions - only latest results are stored in state.
 - Provides methods to manually trigger execution or reset state to initial.
@@ -36,24 +36,24 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
 #### Arguments
 
 - **asyncFn** _`(...params: Args) => Promise<Result>`_ - Function that returns a promise.
-- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation,
+- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation
   before the async function is executed.
 
 #### Return
 
 1. **state**
 
-   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - latest promise status.
-   - **result** _`Result | undefined`_ - promise result if promise fulfilled.
-   - **error** _`Error | undefined`_ - promise error if promise rejected.
+   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - The latest status of the returned promise.
+   - **result** _`Result | undefined`_ - Result of the promise if it was fulfilled.
+   - **error** _`Error | undefined`_ - Result of the promise if it was rejected.
 
-1. **methods**
+2. **methods**
 
-   - **reset** _`() => void`_- Reset state to initial, when async function haven't been executed.
-   - **execute** _`(...args: Args) => Promise<Result>`_- Execute async function manually.
+   - **reset** _`() => void`_- Reset state to initial, when the async function hadn't been executed.
+   - **execute** _`(...args: Args) => Promise<Result>`_- Execute the async function manually.
 
-1. **meta**
+2. **meta**
 
-   - **promise** _`Promise<Result> | undefined`_- Recent promise returned from async function.
-   - **lastArgs** _`Args | undefined`_ - List of arguments applied to recent async function
+   - **promise** _`Promise<Result> | undefined`_- Latest promise returned from the async function.
+   - **lastArgs** _`Args | undefined`_ - List of arguments applied to the latest async function
      invocation.

--- a/src/useAsync/useAsync.ts
+++ b/src/useAsync/useAsync.ts
@@ -28,7 +28,7 @@ export type AsyncState<Result> =
 
 export interface UseAsyncActions<Result, Args extends unknown[] = unknown[]> {
   /**
-   * Reset state to initial, when the async function hadn't been executed.
+   * Reset state to initial.
    */
   reset: () => void;
   /**

--- a/src/useAsync/useAsync.ts
+++ b/src/useAsync/useAsync.ts
@@ -28,22 +28,22 @@ export type AsyncState<Result> =
 
 export interface UseAsyncActions<Result, Args extends unknown[] = unknown[]> {
   /**
-   * Reset state to initial, when async function haven't been executed.
+   * Reset state to initial, when the async function hadn't been executed.
    */
   reset: () => void;
   /**
-   * Execute async function manually.
+   * Execute the async function manually.
    */
   execute: (...args: Args) => Promise<Result>;
 }
 
 export interface UseAsyncMeta<Result, Args extends unknown[] = unknown[]> {
   /**
-   * Recent promise returned from async function.
+   * Latest promise returned from the async function.
    */
   promise: Promise<Result> | undefined;
   /**
-   * List of arguments applied to recent async function invocation.
+   * List of arguments applied to the latest async function invocation.
    */
   lastArgs: Args | undefined;
 }
@@ -58,10 +58,10 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
 ): [AsyncState<Result | undefined>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>];
 
 /**
- * Tracks result and error of provided async function and provides handles to execute and reset it.
+ * Tracks the result and errors of the provided async function and provides handles to control its execution.
  *
  * @param asyncFn Function that returns a promise.
- * @param initialValue Value that will be set on initialisation, before the async function is
+ * @param initialValue Value that will be set on initialisation before the async function is
  * executed.
  */
 export function useAsync<Result, Args extends unknown[] = unknown[]>(

--- a/src/useAsyncAbortable/__docs__/story.mdx
+++ b/src/useAsyncAbortable/__docs__/story.mdx
@@ -1,15 +1,15 @@
-import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Example } from './example.stories';
-import { ImportPath } from '../../__docs__/ImportPath';
+import {Canvas, Meta, Story} from '@storybook/addon-docs';
+import {Example} from './example.stories';
+import {ImportPath} from '../../__docs__/ImportPath';
 
 <Meta title="Side-effect/useAsyncAbortable" component={Example} />
 
 # useAsyncAbortable
 
-Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.
+Like `useAsync`, but also provides `AbortSignal` as the first argument to the async function.
 
-- All the advantages of `useAsync`
-- Automatically aborts previously invoked async.
+- All the advantages of `useAsync`.
+- Automatically aborts previous invocations of the async function.
 - Provides `abort` handle.
 
 #### Example
@@ -39,28 +39,27 @@ export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
 
 - **asyncFn** _`(...params: ArgsWithAbortSignal<Args>) => Promise<Result>`_ - Function that returns
   a promise.
-- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation,
+- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation
   before the async function is executed.
 
 #### Return
 
 1. **state**
 
-   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - Latest promise status.
-   - **result** _`Result | undefined`_ - Promise result if promise fulfilled.
-   - **error** _`Error | undefined`_ - Promise error if promise rejected.
+   - **status** _`'loading' | 'success' | 'error' | 'not-executed'`_ - The latest status of the returned promise.
+   - **result** _`Result | undefined`_ - Result of the promise if it was fulfilled.
+   - **error** _`Error | undefined`_ - Result of the promise if it was rejected.
 
-1. **methods**
+2. **methods**
 
-   - **reset** _`() => void`_- Abort currently running async and reset state to initial, when async
-     function haven't been executed.
-   - **execute** _`(...args: Args) => Promise<Result>`_- Execute async function manually.
-   - **abort** _`() => void`_- Abort currently running async.
+   - **reset** _`() => void`_- Reset state to initial, when the async function hadn't been executed.
+   - **execute** _`(...args: Args) => Promise<Result>`_- Execute the async function manually.
+   - **abort** _`() => void`_- Abort the currently running async function invocation.
 
-1. **meta**
+3. **meta**
 
-   - **promise** _`Promise<Result> | undefined`_- Recent promise returned from async function.
-   - **lastArgs** _`Args | undefined`_ - List of arguments applied to recent async function
+   - **promise** _`Promise<Result> | undefined`_- Latest promise returned from the async function.
+   - **lastArgs** _`Args | undefined`_ - List of arguments applied to the latest async function
      invocation.
-   - **abortController** _`AbortController | undefined`_ - Current abort controller. New one created
-     each async execution.
+   - **abortController** _`AbortController | undefined`_ - Currently used `AbortController`. New one
+     is created on each execution of the async function.

--- a/src/useAsyncAbortable/__docs__/story.mdx
+++ b/src/useAsyncAbortable/__docs__/story.mdx
@@ -39,7 +39,7 @@ export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
 
 - **asyncFn** _`(...params: ArgsWithAbortSignal<Args>) => Promise<Result>`_ - Function that returns
   a promise.
-- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation
+- **initialValue** _`Result`_ _(default: `undefined`)_ - Value that will be set on initialisation,
   before the async function is executed.
 
 #### Return
@@ -52,7 +52,7 @@ export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
 
 2. **methods**
 
-   - **reset** _`() => void`_- Reset state to initial, when the async function hadn't been executed.
+   - **reset** _`() => void`_- Abort the currently running async function invocation and reset state to initial.
    - **execute** _`(...args: Args) => Promise<Result>`_- Execute the async function manually.
    - **abort** _`() => void`_- Abort the currently running async function invocation.
 

--- a/src/useAsyncAbortable/useAsyncAbortable.ts
+++ b/src/useAsyncAbortable/useAsyncAbortable.ts
@@ -1,15 +1,15 @@
 import { useMemo, useRef } from 'react';
-import { useAsync, UseAsyncMeta, UseAsyncActions, AsyncState } from '../useAsync/useAsync';
+import { AsyncState, useAsync, UseAsyncActions, UseAsyncMeta } from '../useAsync/useAsync';
 
 export interface UseAsyncAbortableActions<Result, Args extends unknown[] = unknown[]>
   extends UseAsyncActions<Result, Args> {
   /**
-   *  Abort currently running async.
+   *  Abort the currently running async function invocation.
    */
   abort: () => void;
 
   /**
-   * Abort currently running async and reset state to initial, when async function haven't been executed.
+   * Reset state to initial, when the async function hadn't been executed.
    */
   reset: () => void;
 }
@@ -17,7 +17,7 @@ export interface UseAsyncAbortableActions<Result, Args extends unknown[] = unkno
 export interface UseAsyncAbortableMeta<Result, Args extends unknown[] = unknown[]>
   extends UseAsyncMeta<Result, Args> {
   /**
-   * Current abort controller. New one created each async execution.
+   * Currently used `AbortController`. New one is created on each execution of the async function.
    */
   abortController: AbortController | undefined;
 }
@@ -42,10 +42,10 @@ export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(
 ];
 
 /**
- * Like `useAsync`, but also provides `AbortSignal` as first function argument to async function.
+ * Like `useAsync`, but also provides `AbortSignal` as the first argument to the async function.
  *
  * @param asyncFn Function that returns a promise.
- * @param initialValue Value that will be set on initialisation, before the async function is
+ * @param initialValue Value that will be set on initialisation before the async function is
  * executed.
  */
 export function useAsyncAbortable<Result, Args extends unknown[] = unknown[]>(

--- a/src/useAsyncAbortable/useAsyncAbortable.ts
+++ b/src/useAsyncAbortable/useAsyncAbortable.ts
@@ -9,7 +9,7 @@ export interface UseAsyncAbortableActions<Result, Args extends unknown[] = unkno
   abort: () => void;
 
   /**
-   * Reset state to initial, when the async function hadn't been executed.
+   * Abort the currently running async function invocation and reset state to initial.
    */
   reset: () => void;
 }

--- a/src/useCookieValue/__docs__/story.mdx
+++ b/src/useCookieValue/__docs__/story.mdx
@@ -1,5 +1,5 @@
-import { Canvas, Meta, Story, Source } from '@storybook/addon-docs';
-import { Example } from './example.stories';
+import {Canvas, Meta, Source, Story} from '@storybook/addon-docs';
+import {Example} from './example.stories';
 
 <Meta title="Side-effect/useCookieValue" component={Example} />
 
@@ -7,24 +7,24 @@ import { Example } from './example.stories';
 
 Manages a single cookie.
 
-> **IMPORTANT**: Requires separate installation of `js-cookie` package.
+> **IMPORTANT**: Requires separate installation of the `js-cookie` package.
 
-> **IMPORTANT**: This hook should be directly imported as it has optional dependency and therefore
-> it is not exported from index file. See [importing](#importing) section below.
+> **IMPORTANT**: This hook should be directly imported as it has an optional dependency and therefore
+> is not exported from the index file. See [importing](#importing) section below.
 
-- Uses `js-cookie` package underneath.
+- Uses the `js-cookie` package underneath.
 - SSR-friendly.
 - Hooks with the same key on the same page are synchronised. This synchronisation does not work
   across tabs or on changes that are triggered by third-party code.
 
-> **_This hook provides stable API, meaning returned methods does not change between renders_**
+> **_This hook provides a stable API, meaning returned methods do not change between renders_**
 
-> Uses `null` values as indicator of cookie absence, `undefined` value means that cookie value
+> Uses `null` value as the indicator of cookie absence. `undefined` value means that the cookie value
 > hasn't been fetched yet.
 
-> While using SSR, to avoid hydration mismatch, consider setting `initializeWithValue` option to
-> `false`, this will yield `undefined` state on first render and defer value fetch till effects
-> execution stage.
+> While using SSR, to avoid hydration mismatch, consider setting the `initializeWithValue` option to
+> `false`. This will make the hook yield `undefined` on first render and defer fetching of the cookie
+> value until effects are executed.
 
 #### Example
 
@@ -64,17 +64,16 @@ import { useCookieValue } from '@react-hookz/web/esnext/useCookieValue/useCookie
 
 #### Arguments
 
-- **key** _`string`_ - Cookie name to manage.
-- **options** _`UseCookieOptions`_ _(default: {})_ - Cookie options that will be used during cookie
-  set and delete. Has only one extra option, that relates to the hook itself:
-  - **initializeWithValue** _`boolean`_ _(default: true)_ - Whether to initialize state with cookie
-    value or initialize with `undefined` state.  
-    _Default to `false` during SSR._
+- **key** _`string`_ - Name of the cookie to manage.
+- **options** _`UseCookieOptions`_ _(default: {})_ - Cookie options that will be used during setting
+    and deleting the cookie. Has one extra option, that relates to the hook itself:
+  - **initializeWithValue** _`boolean`_ _(default: true)_ - Whether to initialize state with the cookie
+    value or `undefined`. _We suggest setting this to `false` during SSR._
 
 #### Return
 
-0. **state** - cookie value, `undefined` means it is not fetched yet, `null` means absence of
-   cookie.
-1. **set** - Method to set new cookie value.
-2. **remove** - Method to remove cookie.
-3. **fetch** - Method to re-fetch cookie value.
+0. **state** - Value of the managed cookie. `undefined` means the value has not been fetched yet,
+    `null` means the cookie is absent.
+1. **set** - Set new value to the cookie.
+2. **remove** - Remove the cookie.
+3. **fetch** - Re-fetch the cookie value.

--- a/src/useCookieValue/__docs__/story.mdx
+++ b/src/useCookieValue/__docs__/story.mdx
@@ -12,7 +12,7 @@ Manages a single cookie.
 > **IMPORTANT**: This hook should be directly imported as it has an optional dependency and therefore
 > is not exported from the index file. See [importing](#importing) section below.
 
-- Uses the `js-cookie` package underneath.
+- Uses the `js-cookie` package under the hood.
 - SSR-friendly.
 - Hooks with the same key on the same page are synchronised. This synchronisation does not work
   across tabs or on changes that are triggered by third-party code.

--- a/src/useCookieValue/useCookieValue.ts
+++ b/src/useCookieValue/useCookieValue.ts
@@ -56,9 +56,9 @@ export type UseCookieValueOptions<
   (InitializeWithValue extends undefined
     ? {
         /**
-         * Whether to initialize state with cookie value or initialize with `undefined` state.
+         * Whether to initialize state with the cookie value or `undefined`.
          *
-         * Default to false during SSR
+         * _We suggest setting this to `false` during SSR._
          *
          * @default true
          */
@@ -82,8 +82,8 @@ export function useCookieValue(
 /**
  * Manages a single cookie.
  *
- * @param key Cookie name to manage.
- * @param options Cookie options that will be used during cookie set and delete.
+ * @param key Name of the cookie to manage.
+ * @param options Cookie options that will be used during setting and deleting the cookie.
  */
 export function useCookieValue(
   key: string,

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -16,7 +16,7 @@ Manages a single LocalStorage key.
 > **_This hook provides a stable API, meaning the returned methods do not change between renders._**
 
 > Does not allow usage of `null` as a value, since JSON allows serializing `null` - it would be
-> impossible to separate `null` value fom 'no such value' API result which is also `null`.
+> impossible to separate `null` value from 'no such value' API result which is also `null`.
 
 > If you are doing SSR, set `initializeWithValue` to `false` in order for this hook to return
 > `undefined` on first render. The LocalStorage value will be fetched client-side when effects
@@ -67,7 +67,7 @@ function useLocalStorageValue<
 
 #### Return
 
-Object with following properties. Note, that this object changes with `value`, but its methods are
+Object with following properties. Note that this object changes with `value`, but its methods are
 stable between renders. Thus, it is safe to pass them as props.
 - **value** - LocalStorage value of the given `key` argument or `defaultValue`, if the key was not
 present.

--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -13,10 +13,10 @@ Manages a single LocalStorage key.
 - Synchronized between all hooks on the page with the same key.
 - SSR compatible.
 
-> **_This hook provides stable API, meaning the returned methods do not change between renders._**
+> **_This hook provides a stable API, meaning the returned methods do not change between renders._**
 
-> Does not allow usage of `null` value, since JSON allows serializing `null` values - it would be
-> impossible to separate null value fom 'no such value' API result which is also `null`.
+> Does not allow usage of `null` as a value, since JSON allows serializing `null` - it would be
+> impossible to separate `null` value fom 'no such value' API result which is also `null`.
 
 > If you are doing SSR, set `initializeWithValue` to `false` in order for this hook to return
 > `undefined` on first render. The LocalStorage value will be fetched client-side when effects
@@ -67,10 +67,10 @@ function useLocalStorageValue<
 
 #### Return
 
-Object with following properties. Note that this object changes with value while its methods are
-stable between renders, thus it is safe to pass them as props.
+Object with following properties. Note, that this object changes with `value`, but its methods are
+stable between renders. Thus, it is safe to pass them as props.
 - **value** - LocalStorage value of the given `key` argument or `defaultValue`, if the key was not
 present.
-- **set** - Method to set a new value for the managed `key`.
-- **remove** - Method to remove the current value of `key`.
-- **fetch** - Method to manually retrieve the value of `key`.
+- **set** - Set a new value for the managed `key`.
+- **remove** - Remove the current value of `key`.
+- **fetch** - Manually retrieve the value of `key`.

--- a/src/useSafeState/useSafeState.ts
+++ b/src/useSafeState/useSafeState.ts
@@ -8,7 +8,7 @@ export function useSafeState<S = undefined>(): [
 ];
 
 /**
- * Like `useState` but its state setter is guarded against sets on unmounted component.
+ * Like `useState` but its state setter is guarded against setting the state of an unmounted component.
  */
 export function useSafeState<S>(
   initialState?: S | (() => S)

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -13,10 +13,10 @@ Manages a single SessionStorage key.
 - Synchronized between all hooks on the page with the same key.
 - SSR compatible.
 
-> **_This hook provides stable API, meaning the returned methods do not change between renders._**
+> **_This hook provides a stable API, meaning the returned methods do not change between renders._**
 
-> Does not allow usage of `null` value, since JSON allows serializing `null` values - it would be
-> impossible to separate null value fom 'no such value' API result which is also `null`.
+> Does not allow usage of `null` as a value, since JSON allows serializing `null` - it would be
+> impossible to separate `null` value fom 'no such value' API result which is also `null`.
 
 > If you are doing SSR, set `initializeWithValue` to `false` in order for this hook to return
 > `undefined` on first render. The SessionStorage value will be fetched client-side when effects
@@ -67,10 +67,11 @@ function useSessionStorageValue<
 
 #### Return
 
-Object with following properties. Note that this object changes with value while its methods are 
-stable between renders, thus it is safe to pass them as props.
+
+Object with following properties. Note, that this object changes with `value`, but its methods are
+stable between renders. Thus, it is safe to pass them as props.
 - **value** - SessionStorage value of the given `key` argument or `defaultValue`, if the key was not
 present.
-- **set** - Method to set a new value for the managed `key`.
-- **remove** - Method to remove the current value of `key`.
-- **fetch** - Method to manually retrieve the value of `key`.
+- **set** - Set a new value for the managed `key`.
+- **remove** - Remove the current value of `key`.
+- **fetch** - Manually retrieve the value of `key`.

--- a/src/useSessionStorageValue/__docs__/story.mdx
+++ b/src/useSessionStorageValue/__docs__/story.mdx
@@ -16,7 +16,7 @@ Manages a single SessionStorage key.
 > **_This hook provides a stable API, meaning the returned methods do not change between renders._**
 
 > Does not allow usage of `null` as a value, since JSON allows serializing `null` - it would be
-> impossible to separate `null` value fom 'no such value' API result which is also `null`.
+> impossible to separate `null` value from 'no such value' API result which is also `null`.
 
 > If you are doing SSR, set `initializeWithValue` to `false` in order for this hook to return
 > `undefined` on first render. The SessionStorage value will be fetched client-side when effects
@@ -68,7 +68,7 @@ function useSessionStorageValue<
 #### Return
 
 
-Object with following properties. Note, that this object changes with `value`, but its methods are
+Object with following properties. Note that this object changes with `value`, but its methods are
 stable between renders. Thus, it is safe to pass them as props.
 - **value** - SessionStorage value of the given `key` argument or `defaultValue`, if the key was not
 present.

--- a/src/useStorageValue/useStorageValue.ts
+++ b/src/useStorageValue/useStorageValue.ts
@@ -86,14 +86,15 @@ const removeStorageListener = (s: Storage, key: string, listener: CallableFuncti
 
 export interface UseStorageValueOptions<T, InitializeWithValue extends boolean | undefined> {
   /**
-   * Default value that will be used in absence of value in storage.
+   * Value to return if `key` is not present in LocalStorage.
    *
    * @default undefined
    */
   defaultValue?: T;
 
   /**
-   * Whether to initialize state with storage value or initialize with `undefined` state.
+   * Fetch storage value on first render. If set to `false` will make the hook yield `undefined` on
+   * first render and defer fetching of the value until effects are executed.
    *
    * @default true
    */


### PR DESCRIPTION
## What is the problem?

When I first discovered this repo, the only thing I disliked was that the language in the docs was a bit cluncky at times.

Since good docs are really important for any library, I figured that I might go through them and attempt to improve them as much as I can. I am by no means a native english speaker, so there surely will remain room for improvement.

I plan on going through all of the docs over a few pull requests, so that a single pull request would not get too big to review.

Note that I am attempting to only fix typos and improve the general language, not change what is said in the docs.

## What changes does this PR make to fix the problem?

Fix typos and improve the language in:
- README.md
- CONTRIBUTING.md
- The introduction page
- All of the hooks in the State category
