### PR TITLE
fix(useMediaQuery): On misconfiguration, cause hydration error instea…

### DIFF
--- a/src/useMediaQuery/useMediaQuery.ts
+++ b/src/useMediaQuery/useMediaQuery.ts
@@ -1,4 +1,5 @@
 import { Dispatch, useEffect, useState } from 'react';
+import { isBrowser } from '../util/const';
 
 const queriesMap = new Map<
   string,
@@ -66,9 +67,18 @@ interface UseMediaQueryOptions {
  * `initializeWithValue` (default: `true`) - Determine media query match state on first render. Setting
  * this to false will make the hook yield `undefined` on first render.
  */
-export function useMediaQuery(query: string, options?: UseMediaQueryOptions): boolean | undefined {
+export function useMediaQuery(
+  query: string,
+  options: UseMediaQueryOptions = {}
+): boolean | undefined {
+  let { initializeWithValue = true } = options;
+
+  if (!isBrowser) {
+    initializeWithValue = false;
+  }
+
   const [state, setState] = useState<boolean | undefined>(() => {
-    if (options?.initializeWithValue ?? true) {
+    if (initializeWithValue) {
       let entry = queriesMap.get(query);
       if (!entry) {
         entry = createQueryEntry(query);


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

When the hook is misconfigured, that is, when `initializeWithValue` is `true` during SSR, the hooks crashes instead of producing a hydration error, which is not in line with the behavior of the rest of the isomorphic hooks.

### What is the expected behavior?

Hydration error instead of a crash.

### How does this PR fix the problem?

If the rendering environment is not a browser, set `initializeWithValue` to `false`.

This solution makes me wonder: what is the purpose of the `initializeWithValue` option anymore? If it is set to `false` during SSR anyway, why have it at all? Is there a usecase for having the hook return `undefined` on first render when doing client-side rendering?

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #1000 
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
