### PR TITLE
Migrate `usePromise` from react-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Coming from `react-use`? Check out our
     — Like `useLayoutEffect` but falls back to `useEffect` during SSR.
   - [**`useMountEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usemounteffect--example)
     — Run an effect only when a component mounts.
+  - [**`usePromise`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usepromise--example)
+    — Resolves promise only while component is mounted.
   - [**`useRafEffect`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-useRafEffect--example)
     — Like `useEffect`, but the effect is only run within an animation frame.
   - [**`useRerender`**](https://react-hookz.github.io/web/?path=/docs/lifecycle-usererender--example)

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,3 +116,5 @@ export { resolveHookState } from './util/resolveHookState';
 export * from './types';
 
 export { useDeepCompareMemo } from './useDeepCompareMemo/useDeepCompareMemo';
+
+export { usePromise } from './usePromise/usePromise';

--- a/src/usePromise/__docs__/example.stories.tsx
+++ b/src/usePromise/__docs__/example.stories.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+// import { usePromise } from '../..';
+
+export const Example: React.FC = () => {
+  return null;
+};

--- a/src/usePromise/__docs__/example.stories.tsx
+++ b/src/usePromise/__docs__/example.stories.tsx
@@ -1,6 +1,31 @@
 import * as React from 'react';
-// import { usePromise } from '../..';
+import { useState, useEffect } from 'react';
+import { usePromise } from '../..';
 
 export const Example: React.FC = () => {
-  return null;
+  const mounted = usePromise();
+  const [value, setValue] = useState<string>();
+
+  const myPromise = new Promise((resolve) => {
+    setTimeout(() => {
+      resolve('foo');
+    }, 300);
+  });
+
+  useEffect(() => {
+    (async () => {
+      const res = await mounted(myPromise);
+
+      if (typeof res === 'string') {
+        // This line will not execute if this component gets unmounted.
+        setValue(res);
+      }
+    })();
+  });
+
+  return (
+    <div>
+      <button>{value}</button>
+    </div>
+  );
 };

--- a/src/usePromise/__docs__/story.mdx
+++ b/src/usePromise/__docs__/story.mdx
@@ -6,7 +6,7 @@ import { ImportPath } from '../../storybookUtil/ImportPath';
 
 # usePromise
 
-React Lifecycle hook that returns a helper function for wrapping promises. Promises wrapped with this function will resolve only when component is mounted.
+React lifecycle hook that returns a helper function for wrapping promises. Promises wrapped with this function will resolve only if component is mounted.
 
 #### Example
 
@@ -17,13 +17,16 @@ React Lifecycle hook that returns a helper function for wrapping promises. Promi
 ## Reference
 
 ```ts
-
+usePromise =
+  () =>
+  <T>(promise: Promise<T>) =>
+    Promise<T>;
 ```
 
 #### Importing
 
 <ImportPath />
 
-#### Arguments
-
 #### Return
+
+_`(promise: Promise<T>) => Promise<T>`_ — Function wrapper that for a promise.

--- a/src/usePromise/__docs__/story.mdx
+++ b/src/usePromise/__docs__/story.mdx
@@ -1,0 +1,27 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Example } from './example.stories';
+import { ImportPath } from '../../storybookUtil/ImportPath';
+
+<Meta title="New Hook/usePromise" component={Example} />
+
+# usePromise
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+#### Return

--- a/src/usePromise/__docs__/story.mdx
+++ b/src/usePromise/__docs__/story.mdx
@@ -6,6 +6,8 @@ import { ImportPath } from '../../storybookUtil/ImportPath';
 
 # usePromise
 
+React Lifecycle hook that returns a helper function for wrapping promises. Promises wrapped with this function will resolve only when component is mounted.
+
 #### Example
 
 <Canvas>

--- a/src/usePromise/__tests__/dom.ts
+++ b/src/usePromise/__tests__/dom.ts
@@ -2,6 +2,10 @@ import { renderHook } from '@testing-library/react-hooks/dom';
 import { usePromise } from '../..';
 
 describe('usePromise', () => {
+  const promise = new Promise<number>((resolve) => {
+    resolve(1);
+  });
+
   it('should be defined', () => {
     expect(usePromise).toBeDefined();
   });
@@ -9,5 +13,14 @@ describe('usePromise', () => {
   it('should render', () => {
     const { result } = renderHook(() => usePromise());
     expect(result.error).toBeUndefined();
+  });
+
+  it('should not return if unmounted', async () => {
+    const { result, unmount } = renderHook(() => usePromise());
+    unmount();
+    const res = await result.current(promise);
+
+    expect(result.error).toBeUndefined();
+    expect(res).toBeUndefined();
   });
 });

--- a/src/usePromise/__tests__/dom.ts
+++ b/src/usePromise/__tests__/dom.ts
@@ -26,11 +26,4 @@ describe('usePromise', () => {
 
     await expect(result.current(rejects)).rejects.toBe(Error);
   });
-
-  // Test fails due to being timed out. But it DOES prevent the promise from being called.
-  // test('should not return if unmounted', async () => {
-  //   const { result, unmount } = renderHook(() => usePromise());
-  //   unmount();
-  //   await expect(result.current(resolves)).resolves.toBeUndefined();
-  // });
 });

--- a/src/usePromise/__tests__/dom.ts
+++ b/src/usePromise/__tests__/dom.ts
@@ -1,21 +1,10 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { usePromise } from '../..';
 
-jest.useFakeTimers();
-
 describe('usePromise', () => {
-  const resolves = new Promise<number>((resolve, reject) => {
-    resolve(1);
-    reject(Error);
-  });
-
-  const rejects = new Promise<number>((resolve, reject) => {
-    // eslint-disable-next-line no-constant-condition
-    if (1 < 0) {
-      resolve(1);
-    }
-    reject(Error);
-  });
+  const thenFn = jest.fn();
+  const resolves = Promise.resolve(thenFn);
+  const rejects = Promise.reject(Error);
 
   it('should be defined', () => {
     expect(usePromise).toBeDefined();
@@ -29,23 +18,19 @@ describe('usePromise', () => {
   it('should return resolved value', async () => {
     const { result } = renderHook(() => usePromise());
 
-    await expect(result.current(resolves)).resolves.toBe(1);
+    await expect(result.current(resolves)).resolves.toBe(thenFn);
   });
 
   it('should return rejection value', async () => {
     const { result } = renderHook(() => usePromise());
 
-    expect.assertions(1);
     await expect(result.current(rejects)).rejects.toBe(Error);
   });
 
-  // it('should not return if unmounted', async () => {
+  // Test fails due to being timed out. But it DOES prevent the promise from being called.
+  // test('should not return if unmounted', async () => {
   //   const { result, unmount } = renderHook(() => usePromise());
   //   unmount();
-
-  //   expect(result.error).toBeUndefined();
   //   await expect(result.current(resolves)).resolves.toBeUndefined();
   // });
 });
-
-jest.clearAllTimers();

--- a/src/usePromise/__tests__/dom.ts
+++ b/src/usePromise/__tests__/dom.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { usePromise } from '../..';
+
+describe('usePromise', () => {
+  it('should be defined', () => {
+    expect(usePromise).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => usePromise());
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/usePromise/__tests__/dom.ts
+++ b/src/usePromise/__tests__/dom.ts
@@ -1,9 +1,20 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { usePromise } from '../..';
 
+jest.useFakeTimers();
+
 describe('usePromise', () => {
-  const promise = new Promise<number>((resolve) => {
+  const resolves = new Promise<number>((resolve, reject) => {
     resolve(1);
+    reject(Error);
+  });
+
+  const rejects = new Promise<number>((resolve, reject) => {
+    // eslint-disable-next-line no-constant-condition
+    if (1 < 0) {
+      resolve(1);
+    }
+    reject(Error);
   });
 
   it('should be defined', () => {
@@ -15,12 +26,26 @@ describe('usePromise', () => {
     expect(result.error).toBeUndefined();
   });
 
-  it('should not return if unmounted', async () => {
-    const { result, unmount } = renderHook(() => usePromise());
-    unmount();
-    const res = await result.current(promise);
+  it('should return resolved value', async () => {
+    const { result } = renderHook(() => usePromise());
 
-    expect(result.error).toBeUndefined();
-    expect(res).toBeUndefined();
+    await expect(result.current(resolves)).resolves.toBe(1);
   });
+
+  it('should return rejection value', async () => {
+    const { result } = renderHook(() => usePromise());
+
+    expect.assertions(1);
+    await expect(result.current(rejects)).rejects.toBe(Error);
+  });
+
+  // it('should not return if unmounted', async () => {
+  //   const { result, unmount } = renderHook(() => usePromise());
+  //   unmount();
+
+  //   expect(result.error).toBeUndefined();
+  //   await expect(result.current(resolves)).resolves.toBeUndefined();
+  // });
 });
+
+jest.clearAllTimers();

--- a/src/usePromise/__tests__/ssr.ts
+++ b/src/usePromise/__tests__/ssr.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { usePromise } from '../..';
+
+describe('usePromise', () => {
+  it('should be defined', () => {
+    expect(usePromise).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => usePromise());
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/usePromise/usePromise.ts
+++ b/src/usePromise/usePromise.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useIsMounted } from '../useIsMounted/useIsMounted';
-import { noop } from '../util/const';
 
 export type UsePromise = () => <T>(promise: Promise<T>) => Promise<T>;
 
@@ -10,9 +9,9 @@ export const usePromise: UsePromise = () => {
   return useCallback(
     <T>(promise: Promise<T>) =>
       new Promise<T>((resolve, reject) => {
-        const onResolve = (resolution: T) => (isMounted() ? resolve(resolution) : noop);
+        const onResolve = (resolution: T) => isMounted() && resolve(resolution);
 
-        const onReject = (rejection: unknown) => (isMounted() ? reject(rejection) : noop);
+        const onReject = (rejection: unknown) => isMounted() && reject(rejection);
 
         // eslint-disable-next-line promise/catch-or-return
         promise.then(onResolve, onReject);

--- a/src/usePromise/usePromise.ts
+++ b/src/usePromise/usePromise.ts
@@ -1,19 +1,18 @@
 import { useCallback } from 'react';
 import { useIsMounted } from '../useIsMounted/useIsMounted';
+import { noop } from '../util/const';
 
 export type UsePromise = () => <T>(promise: Promise<T>) => Promise<T>;
 
 export const usePromise: UsePromise = () => {
   const isMounted = useIsMounted();
+
   return useCallback(
     <T>(promise: Promise<T>) =>
       new Promise<T>((resolve, reject) => {
-        const onResolve = (resolution: T) => {
-          return isMounted() && resolve(resolution);
-        };
-        const onReject = (rejection: T) => {
-          return isMounted() && reject(rejection);
-        };
+        const onResolve = (resolution: T) => (isMounted() ? resolve(resolution) : noop);
+
+        const onReject = (rejection: unknown) => (isMounted() ? reject(rejection) : noop);
 
         // eslint-disable-next-line promise/catch-or-return
         promise.then(onResolve, onReject);

--- a/src/usePromise/usePromise.ts
+++ b/src/usePromise/usePromise.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useIsMounted } from '../useIsMounted/useIsMounted';
+
+export type UsePromise = () => <T>(promise: Promise<T>) => Promise<T>;
+
+export const usePromise: UsePromise = () => {
+  const isMounted = useIsMounted();
+  return useCallback(
+    <T>(promise: Promise<T>) =>
+      new Promise<T>((resolve, reject) => {
+        const onResolve = (resolution: T) => {
+          return isMounted() && resolve(resolution);
+        };
+        const onReject = (rejection: T) => {
+          return isMounted() && reject(rejection);
+        };
+
+        // eslint-disable-next-line promise/catch-or-return
+        promise.then(onResolve, onReject);
+      }),
+    [isMounted]
+  );
+};


### PR DESCRIPTION
## What new hook does?
Resolves promise only while the component is mounted.

I ran into a problem with testing. Maybe someone can help me out with it. More or less, I need to test that when unmounted, a promise is not returned. However, not returning a promise will break the test due to timeout. This is the test I was using:

```ts
test('should not return if unmounted', async () => {
    const { result, unmount } = renderHook(() => usePromise());
    unmount();
    await expect(result.current(resolves)).resolves.toBeUndefined();
  });
```

And I tried about a million variations. I AM new to writing tests, so I might be missing something simple. I figured instead of spinning wheels on this I would get a PR up and let yall chime in. 

Cheers

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have the tests been added to cover new hook?
- [x] Have you run the tests locally to confirm they pass?
