### PR TITLE
fix(useEventListener): change the way listener added and removed

### DIFF
--- a/src/useEventListener/useEventListener.ts
+++ b/src/useEventListener/useEventListener.ts
@@ -2,7 +2,7 @@
 import { RefObject, useEffect, useMemo } from 'react';
 import { useIsMounted } from '../useIsMounted/useIsMounted';
 import { useSyncedRef } from '../useSyncedRef/useSyncedRef';
-import { hasOwnProperty } from '../util/misc';
+import { hasOwnProperty, off, on } from '../util/misc';
 
 /**
  *  An HTML element or ref object containing an HTML element.
@@ -53,10 +53,10 @@ export function useEventListener<T extends EventTarget>(
     const restParams = params.slice(2);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    tgt.addEventListener(params[0], eventListener, ...restParams);
+    on(tgt, params[0], eventListener, ...restParams);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return () => tgt.removeEventListener(params[0], eventListener, ...restParams);
+    return () => off(tgt, params[0], eventListener, ...restParams);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target, params[0]]);
 }


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

It is possible to break the code bypassing types

### What is the expected behavior?

Hook should stay vaiable even in case of improper input

### How does this PR fix the problem?

Change raw `addEventListener`/`removeEventListener` to internal `on`/`off` methods that has proper checks.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - #978 
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
