### PR TITLE
Update PR template and contribution guide in regards to submitting new hooks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new-hook.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-hook.md
@@ -1,12 +1,20 @@
-## What new hook does?
+## Hook description
+
+- Describe the new hook. What does it do?
+
+### Valid use-case for the hook
+
+- How would the hook be used in a real application?
 
 ## Checklist
 
-- [ ] Have you read [contribution guideline](../../CONTRIBUTING.md)?
+- [ ] Have you read the [contribution guidelines](../../CONTRIBUTING.md)?
+- [ ] If you are porting a hook from `react-use`, have you checked #33 and the [migration guide](../../src/__docs__/migrating-from-react-use.story.mdx)
+      to confirm that the hook has been approved for porting?
 - [ ] Does the code have comments in hard-to-understand areas?
 - [ ] Is there an existing issue for this PR?
   - _link issue here_
 - [ ] Have the files been linted and formatted?
 - [ ] Have the docs been updated?
-- [ ] Have the tests been added to cover new hook?
+- [ ] Have you written tests for the new hook?
 - [ ] Have you run the tests locally to confirm they pass?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,18 @@ If you are contributing for the first time, we recommend reading this
    standards.
 7. `yarn new-hook myAwesomeHook` will help you to create a proper file structure for the new hook.
 
+### Notes on porting a hook from `react-use`
+
+- Check from #33 and the [migration guide](src/__docs__/migrating-from-react-use.story.mdx)
+  that the hook has been approved for porting. If there is no previous discussion on the hook in #33,
+  leave a comment there asking if you could port the hook. In your comment, provide a valid use-case
+  for the hook.
+- Don't just copy-paste the hook. Think through the code:
+  - Is there sufficient tests?
+  - Could the hook be implemented by reusing existing hooks in `@react-hookz/web`?
+  - Is the documentation exhaustive?
+  - Is the example useful?
+
 ## Committing
 
 ### Commit message


### PR DESCRIPTION
## What is the problem?

Sometimes PR's for new hooks are submitted and they are rejected, because the hooks have no valid use-case. This is
often the case for hooks ported from `react-use`.

This is of course unfortunate for the contributors who end up wasting time writing code that will not be merged.

## What changes does this PR make to fix the problem?

- Added a section to the PR template asking to check #33 and the migration guide to see whether a hook from `react-use` has been approved for porting.
- Added a section to the PR template asking a valid use-case to be provided for all new hooks.
- Added a small section to the contribution guide with some general notes about porting hooks from `react-use`, including everything that was added to the PR template.
