### PR TITLE
fix: 'add new hook' helper

### DIFF
--- a/utility/add-new-hook.js
+++ b/utility/add-new-hook.js
@@ -47,7 +47,7 @@ export const Example: React.FC = () => {
     path.resolve(hookDir, `__docs__/story.mdx`),
     `import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { Example } from './example.stories';
-import { ImportPath } from '../../storybookUtil/ImportPath';
+import { ImportPath } from '../../__docs__/ImportPath';
 
 <Meta title="New Hook/${hookName}" component={Example} />
 


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

After generate new hook cmd: `yarn storybook:build` throws error

### What is the expected behavior?

storybook runs correctly

### How does this PR fix the problem?

fix pathname of `<ImportPath />` component

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated to match the changes in the PR?
- [X] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?
