### PR TITLE
`useResponsiveText`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Coming from `react-use`? Check out our
     — Subscribes an event listener to a target element.
   - [**`useKeyboardEvent`**](https://react-hookz.github.io/web/?path=/docs/dom-usekeyboardevent--example)
     — Invokes a callback when a keyboard event occurs on the chosen target.
+  - [**`useResponsiveText`**](https://react-hookz.github.io/web/?path=/docs/dom-useresponsivetext--example)
+    — Style referenced element to have a `font-size` thats a percentage of its parent element.
   - [**`useWindowSize`**](https://react-hookz.github.io/web/?path=/docs/dom-usewindowsize--example)
     — Tracks the inner dimensions of the browser window.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,3 +78,5 @@ export { resolveHookState } from './util/resolveHookState';
 
 // Types
 export * from './types';
+
+export * from './useResponsiveText';

--- a/src/useResponsiveText/__docs__/example.stories.tsx
+++ b/src/useResponsiveText/__docs__/example.stories.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-// import { useResponsiveText } from '../..';
+import { useResponsiveText } from '../..';
 
 export const Example: React.FC = () => {
-  return null;
+  const [headingRef] = useResponsiveText<HTMLHeadingElement>(10);
+
+  return (
+    <div>
+      <p>Resize the window to change it&apos;s size.</p>
+      <h1 ref={headingRef}>Responsive!</h1>
+    </div>
+  );
 };

--- a/src/useResponsiveText/__docs__/example.stories.tsx
+++ b/src/useResponsiveText/__docs__/example.stories.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+// import { useResponsiveText } from '../..';
+
+export const Example: React.FC = () => {
+  return null;
+};

--- a/src/useResponsiveText/__docs__/story.mdx
+++ b/src/useResponsiveText/__docs__/story.mdx
@@ -2,9 +2,11 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { Example } from './example.stories';
 import { ImportPath } from '../../__docs__/ImportPath';
 
-<Meta title="New Hook/useResponsiveText" component={Example} />
+<Meta title="DOM/useResponsiveText" component={Example} />
 
 # useResponsiveText
+
+Style the referenced element to have a `font-size` thats a percentage of its parent element.
 
 #### Example
 
@@ -15,7 +17,7 @@ import { ImportPath } from '../../__docs__/ImportPath';
 ## Reference
 
 ```ts
-
+export function useResponsiveText<T extends HTMLElement>(percentage = 5): [RefObject<T>];
 ```
 
 #### Importing
@@ -24,4 +26,8 @@ import { ImportPath } from '../../__docs__/ImportPath';
 
 #### Arguments
 
+- **percentage** _`number`_ _(default: 5)_ - `font-size` percentage of the parent element.
+
 #### Return
+
+- **ref** _`[RefObject<T>]`_ - Ref Object to be used on the target element

--- a/src/useResponsiveText/__docs__/story.mdx
+++ b/src/useResponsiveText/__docs__/story.mdx
@@ -1,0 +1,27 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Example } from './example.stories';
+import { ImportPath } from '../../__docs__/ImportPath';
+
+<Meta title="New Hook/useResponsiveText" component={Example} />
+
+# useResponsiveText
+
+#### Example
+
+<Canvas>
+  <Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+#### Return

--- a/src/useResponsiveText/__tests__/dom.ts
+++ b/src/useResponsiveText/__tests__/dom.ts
@@ -10,4 +10,11 @@ describe('useResponsiveText', () => {
     const { result } = renderHook(() => useResponsiveText());
     expect(result.error).toBeUndefined();
   });
+
+  it('should return a ref', () => {
+    const { result } = renderHook(() => useResponsiveText());
+    const [ref] = result.current;
+
+    expect(ref).toBeTruthy();
+  });
 });

--- a/src/useResponsiveText/__tests__/dom.ts
+++ b/src/useResponsiveText/__tests__/dom.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
+
 import { useResponsiveText } from '../..';
 
 describe('useResponsiveText', () => {
@@ -12,7 +13,7 @@ describe('useResponsiveText', () => {
   });
 
   it('should return a ref', () => {
-    const { result } = renderHook(() => useResponsiveText());
+    const { result } = renderHook(() => useResponsiveText(10));
     const [ref] = result.current;
 
     expect(ref).toBeTruthy();

--- a/src/useResponsiveText/__tests__/dom.ts
+++ b/src/useResponsiveText/__tests__/dom.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useResponsiveText } from '../..';
+
+describe('useResponsiveText', () => {
+  it('should be defined', () => {
+    expect(useResponsiveText).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useResponsiveText());
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/useResponsiveText/__tests__/ssr.ts
+++ b/src/useResponsiveText/__tests__/ssr.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useResponsiveText } from '../..';
+
+describe('useResponsiveText', () => {
+  it('should be defined', () => {
+    expect(useResponsiveText).toBeDefined();
+  });
+
+  it('should render', () => {
+    const { result } = renderHook(() => useResponsiveText());
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/useResponsiveText/index.ts
+++ b/src/useResponsiveText/index.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+import type { RefObject } from 'react';
+import { useWindowSize } from '../useWindowSize';
+
+/**
+ * Will style the referenced text to be at the chosen percentage of its parent element.
+ *
+ * @param percentage percentage of the ration between parent and text `default = 5`
+ * @returns `[RefObject<T>]`
+ */
+export function useResponsiveText<T extends HTMLElement | null>(percentage = 5): [RefObject<T>] {
+  const { width } = useWindowSize();
+  const ref = useRef<T>(null);
+
+  const responsiveText = <P extends HTMLElement | null>(flexRef: RefObject<P>) => {
+    const el = flexRef.current;
+    if (flexRef && el) {
+      const relFontsize = (el?.parentElement?.offsetWidth || 0) * (percentage / 100);
+      el.style.fontSize = `${relFontsize}px`;
+    }
+  };
+
+  useEffect(() => {
+    responsiveText<T>(ref);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width]);
+
+  return [ref];
+}

--- a/src/useResponsiveText/index.ts
+++ b/src/useResponsiveText/index.ts
@@ -16,8 +16,8 @@ export function useResponsiveText<T extends HTMLElement | null>(percentage = 5):
   const responsiveText = <P extends HTMLElement | null>(flexRef: RefObject<P>) => {
     const el = flexRef.current;
     if (flexRef && el) {
-      const relFontsize = (el?.parentElement?.offsetWidth || 0) * (percentage / 100);
-      el.style.fontSize = `${relFontsize}px`;
+      const relSize = (el?.parentElement?.offsetWidth || 0) * (percentage / 100);
+      el.style.fontSize = `${relSize}px`;
     }
   };
 


### PR DESCRIPTION
## Hook description

- Describe the new hook. What does it do?
`useResponsiveText` returns a ref that you can use to control the text size of whatever element to to be a percentage of its parent. It can be used for times when you need exact control over the responsiveness of text at every size. 

### Valid use-case for the hook

- How would the hook be used in a real application?
You can see it in this [mock-up](https://octomlmarketingsitemain97959-oc214video.gtsb.io/dummy-video/). The text inside the video component uses it so its always proportionate to the video at ANY size, not just breakpoints. 

## Checklist

- [x] Have you read the [contribution guidelines](../../CONTRIBUTING.md)?
- [x] If you are porting a hook from `react-use`, have you checked #33 and the [migration guide](../../src/__docs__/migrating-from-react-use.story.mdx)
      to confirm that the hook has been approved for porting?
- [x] Does the code have comments in hard-to-understand areas?
- [x] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have you written tests for the new hook?
  - **note** the test coverage is kind of low because I didn't want to add a library to be able to render components in jest. Making it difficult to test the ref'd element. 
- [x] Have you run the tests locally to confirm they pass?
