### PR TITLE
fix(useThrottleCallback): Cleared timeout on unmount

### DIFF
--- a/src/useThrottledCallback/index.ts
+++ b/src/useThrottledCallback/index.ts
@@ -28,6 +28,7 @@ export function useThrottledCallback<Fn extends (...args: any[]) => any>(
   useUnmountEffect(() => {
     if (timeout.current) {
       clearTimeout(timeout.current);
+      timeout.current = undefined;
     }
   });
 


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

- NextJS application
- Use `useThrottledCallback` anywhere
- Notice that it's only called once and then never again

### What is the expected behavior?

Method should be called and limited to throttling frequency.

### How does this PR fix the problem?

Clears the timeout properly.

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
- [X] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?
