### PR TITLE
Fix typos in useIntervalEffect docs, update migration guide

### DIFF
--- a/src/__docs__/migrating-from-react-use.story.mdx
+++ b/src/__docs__/migrating-from-react-use.story.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/addon-docs'
+import { Meta } from '@storybook/addon-docs';
 
 <Meta title="Migrating from react-use" />
 
@@ -238,7 +238,9 @@ Not implemented yet
 
 #### useInterval
 
-Not implemented yet
+Implemented as [useIntervalEffect](/docs/lifecycle-useintervaleffect--example)
+
+No API changes, besides name change.
 
 #### useSpring
 
@@ -498,7 +500,7 @@ No API changes.
 
 #### useEffectOnce
 
-No plans to implement
+Was just an alias for [useMountEffect](/docs/lifecycle-usemounteffect-example) - use that directly instead.
 
 #### useEvent
 

--- a/src/useIntervalEffect/__docs__/story.mdx
+++ b/src/useIntervalEffect/__docs__/story.mdx
@@ -1,10 +1,10 @@
-import {Canvas, Meta, Story} from '@storybook/addon-docs';
-import {Example} from './example.stories';
-import {ImportPath} from '../../__docs__/ImportPath';
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Example } from './example.stories';
+import { ImportPath } from '../../__docs__/ImportPath';
 
 <Meta title="Lifecycle/useIntervalEffect" component={Example} />
 
-# useInterval
+# useIntervalEffect
 
 Like `setInterval` but in the form of a React hook.
 

--- a/src/useIntervalEffect/__tests__/dom.ts
+++ b/src/useIntervalEffect/__tests__/dom.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks/dom';
 import { useIntervalEffect } from '../..';
 import advanceTimersByTime = jest.advanceTimersByTime;
 
-describe('useInterval', () => {
+describe('useIntervalEffect', () => {
   beforeAll(() => {
     jest.useFakeTimers();
   });

--- a/src/useIntervalEffect/__tests__/ssr.ts
+++ b/src/useIntervalEffect/__tests__/ssr.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks/server';
 import { useIntervalEffect } from '../..';
 
-describe('useInterval', () => {
+describe('useIntervalEffect', () => {
   it('should be defined', () => {
     expect(useIntervalEffect).toBeDefined();
   });


### PR DESCRIPTION
## What is the problem?

`useIntervalEffect` was sometimes called `useInterval`.

The migration guide was missing some hooks.

## What changes does this PR make to fix the problem?

Renamed `useInterval` to `useIntervalEffect` everywhere.

Updated the migration guide.
