### PR TITLE
chore(docs): identify that useLocalStorageValue is sync'd across tabs

### DIFF
--- a/src/useLocalStorageValue/__docs__/story.mdx
+++ b/src/useLocalStorageValue/__docs__/story.mdx
@@ -11,6 +11,7 @@ Manages a single LocalStorage key.
 - Uses JSON serialisation to handle non-string values.
 - Tracks window's `storage` event.
 - Synchronized between all hooks on the page with the same key.
+- Synchronized across multiple tabs.
 - SSR compatible.
 
 > **_This hook provides a stable API, meaning the returned methods do not change between renders._**


### PR DESCRIPTION
## What is the problem?
While reading through the migrate from react-use docs I incorrectly determined that the new `useLocalStorageValue` hook was _not_ sync'd across tabs, because of this note

![image](https://github.com/react-hookz/web/assets/4312346/26f2aa00-70d8-48cb-afdc-98dedfec8df3)

## What changes does this PR make to fix the problem?

Explicitly identify in the `useLocalStorageValue()` docs that the value is kept in sync across tabs.

## Checklist

- [ ] Is there an existing issue for this PR?
  - _link issue here_
