### PR TITLE
Pr/use battery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,5 @@ export { resolveHookState } from './util/resolveHookState';
 
 // Types
 export * from './types';
+
+export * from './useBattery';

--- a/src/useBattery/__docs__/example.stories.tsx
+++ b/src/useBattery/__docs__/example.stories.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useBattery } from '../..';
+
+export function Example() {
+	const batteryStats = useBattery();
+	return (
+		<div>
+			<div>Your battery state:</div>
+			<pre>{JSON.stringify(batteryStats, null, 2)}</pre>
+		</div>
+	);
+}

--- a/src/useBattery/__docs__/story.mdx
+++ b/src/useBattery/__docs__/story.mdx
@@ -6,6 +6,11 @@ import { ImportPath } from '../../__docs__/ImportPath';
 
 # useBattery
 
+Hook that tracks battery state.
+
+- Automatically updates on battery state changes.
+- SSR compatible. (Properties return `undefined` on server.)
+
 #### Example
 
 <Canvas>
@@ -15,13 +20,26 @@ import { ImportPath } from '../../__docs__/ImportPath';
 ## Reference
 
 ```ts
-
+export type BatteryState = {
+	/**
+	 * @desc {true} if the battery is charging, {false} otherwise.
+	 */
+	readonly charging: boolean | undefined;
+	/**
+	 * @desc The time remaining in seconds until the system's battery is fully charged.
+	 */
+	readonly chargingTime: number | undefined;
+	/**
+	 * @desc The time remaining in seconds until the system's battery is fully discharged.
+	 */
+	readonly dischargingTime: number | undefined;
+	/**
+	 * @desc The battery level of the system as a number between 0 and 1.
+	 */
+	readonly level: number | undefined;
+};
 ```
 
 #### Importing
 
 <ImportPath />
-
-#### Arguments
-
-#### Return

--- a/src/useBattery/__docs__/story.mdx
+++ b/src/useBattery/__docs__/story.mdx
@@ -1,0 +1,27 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Example } from './example.stories';
+import { ImportPath } from '../../__docs__/ImportPath';
+
+<Meta title="Navigator/useBattery" component={Example} />
+
+# useBattery
+
+#### Example
+
+<Canvas>
+	<Story story={Example} inline />
+</Canvas>
+
+## Reference
+
+```ts
+
+```
+
+#### Importing
+
+<ImportPath />
+
+#### Arguments
+
+#### Return

--- a/src/useBattery/__tests__/dom.ts
+++ b/src/useBattery/__tests__/dom.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useBattery } from '../..';
+
+describe('useBattery', () => {
+	it('should be defined', () => {
+		expect(useBattery).toBeDefined();
+	});
+
+	it('should render', () => {
+		const { result } = renderHook(() => useBattery());
+		expect(result.error).toBeUndefined();
+	});
+});

--- a/src/useBattery/__tests__/dom.ts
+++ b/src/useBattery/__tests__/dom.ts
@@ -10,4 +10,15 @@ describe('useBattery', () => {
 		const { result } = renderHook(() => useBattery());
 		expect(result.error).toBeUndefined();
 	});
+	it('should return an object of certain structure', () => {
+		const hook = renderHook(() => useBattery(), { initialProps: false });
+
+		expect(typeof hook.result.current).toEqual('object');
+		expect(Object.keys(hook.result.current)).toEqual([
+			'charging',
+			'chargingTime',
+			'dischargingTime',
+			'level',
+		]);
+	});
 });

--- a/src/useBattery/__tests__/ssr.ts
+++ b/src/useBattery/__tests__/ssr.ts
@@ -10,4 +10,23 @@ describe('useBattery', () => {
 		const { result } = renderHook(() => useBattery());
 		expect(result.error).toBeUndefined();
 	});
+	it('should return an object of certain structure', () => {
+		const hook = renderHook(() => useBattery(), { initialProps: false });
+
+		expect(typeof hook.result.current).toEqual('object');
+		expect(Object.keys(hook.result.current)).toEqual([
+			'charging',
+			'chargingTime',
+			'dischargingTime',
+			'level',
+		]);
+	});
+	it('should return undefined values', () => {
+		const hook = renderHook(() => useBattery(), { initialProps: false });
+
+		expect(hook.result.current.charging).toBeUndefined();
+		expect(hook.result.current.chargingTime).toBeUndefined();
+		expect(hook.result.current.dischargingTime).toBeUndefined();
+		expect(hook.result.current.level).toBeUndefined();
+	});
 });

--- a/src/useBattery/__tests__/ssr.ts
+++ b/src/useBattery/__tests__/ssr.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useBattery } from '../..';
+
+describe('useBattery', () => {
+	it('should be defined', () => {
+		expect(useBattery).toBeDefined();
+	});
+
+	it('should render', () => {
+		const { result } = renderHook(() => useBattery());
+		expect(result.error).toBeUndefined();
+	});
+});

--- a/src/useBattery/index.ts
+++ b/src/useBattery/index.ts
@@ -14,10 +14,22 @@ import { useEffect, useState } from 'react';
  * In server-side rendering (SSR) environments, the returned values will be undefined.
  */
 export type BatteryState = {
-	charging: boolean | undefined;
-	chargingTime: number | undefined;
-	dischargingTime: number | undefined;
-	level: number | undefined;
+	/**
+	 * @desc {true} if the battery is charging, {false} otherwise.
+	 */
+	readonly charging: boolean | undefined;
+	/**
+	 * @desc The time remaining in seconds until the system's battery is fully charged.
+	 */
+	readonly chargingTime: number | undefined;
+	/**
+	 * @desc The time remaining in seconds until the system's battery is fully discharged.
+	 */
+	readonly dischargingTime: number | undefined;
+	/**
+	 * @desc The battery level of the system as a number between 0 and 1.
+	 */
+	readonly level: number | undefined;
 };
 
 type BatteryManager = {
@@ -33,7 +45,7 @@ type NavigatorWithPossibleBattery = Navigator & {
 
 const nav: NavigatorWithPossibleBattery | undefined = isBrowser ? navigator : undefined;
 /**
- * React hook that tracks battery state.
+ * Hook that tracks battery state.
  *
  * @see https://react-hookz.github.io/web/?path=/docs/navigator-usebattery
  *

--- a/src/useBattery/index.ts
+++ b/src/useBattery/index.ts
@@ -1,0 +1,19 @@
+import { isEqual } from '@react-hookz/deep-equal';
+import { isBrowser } from '../util/const';
+import { useState } from 'react';
+
+export type BatteryState = {
+	charging: boolean | undefined;
+	chargingTime: number | undefined;
+	dischargingTime: number | undefined;
+	level: number | undefined;
+};
+export function useBattery(): BatteryState {
+	const [state, setState] = useState<BatteryState>({
+		charging: undefined,
+		chargingTime: undefined,
+		dischargingTime: undefined,
+		level: undefined,
+	});
+	return state;
+}

--- a/src/useBattery/index.ts
+++ b/src/useBattery/index.ts
@@ -1,13 +1,50 @@
 import { isEqual } from '@react-hookz/deep-equal';
 import { isBrowser } from '../util/const';
-import { useState } from 'react';
+import { off, on } from '../util/misc';
+import { useEffect, useState } from 'react';
 
+/**
+ * The BatteryState interface is the return type of the useBattery Hook.
+ *
+ * provides information about the system's battery charge level
+ * and whether the device is charging, discharging, or fully charged.
+ *
+ * Uses the [BatteryManager](https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager) interface.
+ *
+ * In server-side rendering (SSR) environments, the returned values will be undefined.
+ */
 export type BatteryState = {
 	charging: boolean | undefined;
 	chargingTime: number | undefined;
 	dischargingTime: number | undefined;
 	level: number | undefined;
 };
+
+type BatteryManager = {
+	readonly charging: boolean;
+	readonly chargingTime: number;
+	readonly dischargingTime: number;
+	readonly level: number;
+} & EventTarget;
+
+type NavigatorWithPossibleBattery = Navigator & {
+	getBattery?: () => Promise<BatteryManager>;
+};
+
+const nav: NavigatorWithPossibleBattery | undefined = isBrowser ? navigator : undefined;
+/**
+ * React hook that tracks battery state.
+ *
+ * @see https://react-hookz.github.io/web/?path=/docs/navigator-usebattery
+ *
+ * @returns
+ * - {charging} - whether the system is charging
+ * - {chargingTime} - time remaining in seconds until the system is fully charged
+ * - {dischargingTime} - time remaining in seconds until the system is fully discharged
+ * - {level} - battery level in percent
+ *
+ * In server-side rendering (SSR) environments, the returned values will be undefined.
+ */
 export function useBattery(): BatteryState {
 	const [state, setState] = useState<BatteryState>({
 		charging: undefined,
@@ -15,5 +52,57 @@ export function useBattery(): BatteryState {
 		dischargingTime: undefined,
 		level: undefined,
 	});
+
+	useEffect(() => {
+		let isMounted = true;
+		let battery: BatteryManager | null = null;
+
+		const handleChange = () => {
+			if (!isMounted || !battery) {
+				return;
+			}
+
+			const newState: BatteryState = {
+				level: battery.level,
+				charging: battery.charging,
+				dischargingTime: battery.dischargingTime,
+				chargingTime: battery.chargingTime,
+			};
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			!isEqual(state, newState) && setState(newState);
+		};
+
+		nav
+			?.getBattery?.()
+			.then((bat: BatteryManager) => {
+				// eslint-disable-next-line promise/always-return
+				if (!isMounted) {
+					return;
+				}
+
+				battery = bat;
+				on(battery, 'chargingchange', handleChange);
+				on(battery, 'chargingtimechange', handleChange);
+				on(battery, 'dischargingtimechange', handleChange);
+				on(battery, 'levelchange', handleChange);
+				handleChange();
+			})
+			.catch(() => {
+				// ignore
+			});
+
+		return () => {
+			isMounted = false;
+			if (battery) {
+				off(battery, 'chargingchange', handleChange);
+				off(battery, 'chargingtimechange', handleChange);
+				off(battery, 'dischargingtimechange', handleChange);
+				off(battery, 'levelchange', handleChange);
+			}
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	return state;
 }


### PR DESCRIPTION
## Hook description

- useBattery Hook - uses Navigator.getBattery() to get device battery status.
 
### Valid use-case for the hook

- A full-screen immersive video player which can show a minimal battery status indicator instead of user having to check manually

## Checklist

- [x] Have you read the [contribution guidelines](../../CONTRIBUTING.md)?
- [x] If you are porting a hook from `react-use`, have you checked #33 and the [migration guide](../../src/__docs__/migrating-from-react-use.story.mdx)
      to confirm that the hook has been approved for porting?
- [x] Does the code have comments in hard-to-understand areas?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated?
- [x] Have you written tests for the new hook?
- [x] Have you run the tests locally to confirm they pass?
