### PR TITLE
fix(add-new-hook): use es module import syntax in add-new-hook script

### DIFF
--- a/utility/add-new-hook.js
+++ b/utility/add-new-hook.js
@@ -1,7 +1,5 @@
-// eslint-disable-next-line unicorn/prefer-module
-const fs = require('node:fs/promises');
-// eslint-disable-next-line unicorn/prefer-module
-const path = require('node:path');
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 // eslint-disable-next-line no-void,unicorn/prefer-top-level-await
 void (async () => {


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?
`yarn new-hook useNewHook` fails with an error on the `require()` lines.

### What is the expected behavior?
It creates a new directory and files.

### How does this PR fix the problem?
It uses the ES module import syntax, instead of cjs. It looks like this file was missed in https://github.com/react-hookz/web/pull/1472, which converted everything else to use ES module syntax.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
