### PR TITLE
Fix storage hooks return types

### DIFF
--- a/src/useStorageValue/index.ts
+++ b/src/useStorageValue/index.ts
@@ -118,7 +118,7 @@ type UseStorageValueValue<
 	Default extends Type = Type,
 	Initialize extends boolean | undefined = boolean | undefined,
 	N = Default extends null | undefined ? null | Type : Type,
-	U = Initialize extends false ? undefined | N : N,
+	U = false extends Initialize ? undefined | N : N,
 > = U;
 
 export type UseStorageValueResult<


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?
`useSessionStorageValue` with a `defaultValue` and no `initializeWithValue` returns `typeof defaultValue | undefined`.

### What is the expected behavior?
It should not have `undefined` as a possible return type, as we have a `defaultValue` and `initializeWithValue` defaults to `true`.

### How does this PR fix the problem?
We correctly check that `initializeWithValue` is actually `false`.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
