### PR TITLE
Fix small typo in the  test for useIntersectionObserver hook

### DIFF
--- a/src/useIntersectionObserver/index.dom.test.ts
+++ b/src/useIntersectionObserver/index.dom.test.ts
@@ -105,7 +105,7 @@ describe('useIntersectionObserver', () => {
 		});
 
 		expect(hook1.result.current).toBe(entry1);
-		expect(hook1.result.current).toBe(entry1);
+		expect(hook2.result.current).toBe(entry1);
 	});
 
 	it('should disconnect observer if last hook unmounted', () => {


### PR DESCRIPTION
I think that I found a small typo in the test for useIntersectionObserver hook. 

Two identical lines like below don't make sense to me.
```
expect(hook1.result.current).toBe(entry1);
expect(hook1.result.current).toBe(entry1);
```
I think that author probably wanted it to be like this:
```
expect(hook1.result.current).toBe(entry1);
expect(hook2.result.current).toBe(entry1);
```