### PR TITLE
fix: remove legacy browser API fallbacks

### DIFF
--- a/src/useMediaQuery/index.ts
+++ b/src/useMediaQuery/index.ts
@@ -47,11 +47,7 @@ const queryUnsubscribe = (query: string, setState: QueryStateSetter): void => {
 		if (dispatchers.size === 0) {
 			queriesMap.delete(query);
 
-			if (mql.removeEventListener) {
-				mql.removeEventListener('change', listener);
-			} else {
-				mql.removeListener(listener);
-			}
+			mql.removeEventListener('change', listener);
 		}
 	}
 };

--- a/src/useNetworkState/index.ts
+++ b/src/useNetworkState/index.ts
@@ -66,12 +66,10 @@ export type UseNetworkState = {
 	type: NetworkInformation['type'] | undefined;
 };
 
-type NavigatorWithConnection = Navigator &
-	Partial<Record<'connection' | 'mozConnection' | 'webkitConnection', NetworkInformation>>;
+type NavigatorWithConnection = Navigator & {connection?: NetworkInformation};
 const navigator = isBrowser ? (globalThis.navigator as NavigatorWithConnection) : undefined;
 
-const conn: NetworkInformation | undefined =
-	navigator && (navigator.connection ?? navigator.mozConnection ?? navigator.webkitConnection);
+const conn: NetworkInformation | undefined = navigator?.connection;
 
 function getConnectionState(previousState?: UseNetworkState): UseNetworkState {
 	const online = navigator?.onLine;

--- a/src/usePermission/index.dom.test.ts
+++ b/src/usePermission/index.dom.test.ts
@@ -9,7 +9,7 @@ describe('usePermission', () => {
 			new Promise((resolve) => {
 				setTimeout(() => {
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-					resolve({state: 'prompt'} as PermissionStatus);
+					resolve({state: 'prompt', addEventListener() {}, removeEventListener() {}} as PermissionStatus);
 				}, 1);
 			}),
 	);
@@ -79,6 +79,7 @@ describe('usePermission', () => {
 								// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
 								setTimeout(() => listener(), 1);
 							},
+							removeEventListener() {},
 						};
 
 						resolve(status);

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -6,7 +6,7 @@ export function on<T extends EventTarget>(
 	...args: Parameters<T['addEventListener']> | [string, EventListenerOrEventListenerObject | CallableFunction, ...any]
 ): void {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-	object?.addEventListener?.(...(args as Parameters<HTMLElement['addEventListener']>));
+	object?.addEventListener(...(args as Parameters<HTMLElement['addEventListener']>));
 }
 
 export function off<T extends EventTarget>(
@@ -16,7 +16,7 @@ export function off<T extends EventTarget>(
 		| [string, EventListenerOrEventListenerObject | CallableFunction, ...any]
 ): void {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-	object?.removeEventListener?.(...(args as Parameters<HTMLElement['removeEventListener']>));
+	object?.removeEventListener(...(args as Parameters<HTMLElement['removeEventListener']>));
 }
 
 export const hasOwnProperty = <T extends Record<string | number | symbol, any>, K extends string | number | symbol>(


### PR DESCRIPTION
## Summary

Removes the remaining code paths that pretend standard browser APIs may be missing. `createQueryEntry` in `useMediaQuery` subscribes with `addEventListener` unconditionally, so the deprecated `removeListener` fallback in `queryUnsubscribe` was asymmetric dead code — and the same "API might not exist" defensiveness lingered in `useNetworkState` and the shared `on`/`off` helpers.

## Changes

- `useMediaQuery`: `queryUnsubscribe` uses `removeEventListener` directly, matching `createQueryEntry` (Safari < 14 fallback removed)
- `useNetworkState`: dropped `mozConnection`/`webkitConnection` — every browser shipping the Network Information API exposes unprefixed `navigator.connection`; Firefox and Safari don't ship it at all
- `util/misc.ts`: `on`/`off` no longer optional-chain `addEventListener`/`removeEventListener` — the `EventTarget` constraint guarantees the methods exist; a non-EventTarget target now throws instead of silently doing nothing
- `usePermission` tests: mocks gained the listener methods a real `PermissionStatus` always has (the silent no-op in `on`/`off` was masking the incomplete mocks)

## Testing

- `yarn lint`
- `yarn test` — full suite, 527 tests across 117 files
- `yarn build`