### PR TITLE
chore(package): add package.json as an export

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"sideEffects": false,
 	"exports": {
 		".": "./dist/index.js",
+		"./package.json": "./package.json",
 		"./*/": "./dist/*/index.js",
 		"./*": "./dist/*"
 	},


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

When using @react-hookz/web in a component library (like a design system) that uses Storybook, Storybook browses dependencies looking for some dedicated meta in each dependency "package.json" file (`storybook` field).

But as @react-hooks/web does not export its "package.json" file, Storybook spits the following warning:

> unable to find package.json for @react-hookz/web

Its not really an issue, more an annoyance.

### What is the expected behavior?

Storybook has access to @react-hooks/web's "package.json" file.

### How does this PR fix the problem?

Simply by adding "package.json" as an export of itself :-)

## Checklist

- [X] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Is there an existing issue for this PR?
- [X] Have the files been linted and formatted?
- [X] Have the docs been updated to match the changes in the PR?
- [X] Have the tests been updated to match the changes in the PR?
- [X] Have you run the tests locally to confirm they pass?
