### PR TITLE
chore(ts): revise the TypeScript setup for TS 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"@types/node": "^26.1.1",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
-		"@ver0/oxlint-config": "^2.0.0",
+		"@ver0/oxlint-config": "^2.0.2",
 		"@ver0/react-hooks-testing": "^1.0.3",
 		"@vitest/coverage-v8": "^4.1.10",
 		"js-cookie": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"lint": "vp lint",
 		"lint:fix": "vp lint --fix",
 		"test": "vp test --run",
-		"test:coverage": "vp test --run --coverage"
+		"test:coverage": "vp test --run --coverage",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@ver0/deep-equal": "^2.0.1"

--- a/src/useAsyncAbortable/index.dom.test.ts
+++ b/src/useAsyncAbortable/index.dom.test.ts
@@ -45,7 +45,7 @@ describe('useAsyncAbortable', () => {
 	});
 
 	it('should pass abort signal as first argument', async () => {
-		const spy = vi.fn(async (s: AbortSignal, n: number) => n);
+		const spy = vi.fn(async (_s: AbortSignal, n: number) => n);
 		const {result} = await renderHook(() => useAsyncAbortable(spy));
 
 		await act(async () => {

--- a/src/useAsyncAbortable/index.dom.test.ts
+++ b/src/useAsyncAbortable/index.dom.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook} from '@ver0/react-hooks-testing';
 import {describe, expect, it, vi} from 'vitest';
 import {useAsyncAbortable} from '../index.js';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectResultValue} from '../util/testing/test-helpers.js';
 
 function getControllableAsync<Response, Args extends unknown[] = unknown[]>() {
 	const resolve: {current: undefined | ((result: Response) => void)} = {current: undefined};
@@ -53,9 +53,9 @@ describe('useAsyncAbortable', () => {
 			void hookValue[1].execute(123);
 		});
 
-		expect(spy.mock.calls[0][0]).toBeInstanceOf(AbortSignal);
-		expect(spy.mock.calls[0][0].aborted).toBe(false);
-		expect(spy.mock.calls[0][1]).toBe(123);
+		expect(expectCallArgs(spy, 0)[0]).toBeInstanceOf(AbortSignal);
+		expect(expectCallArgs(spy, 0)[0].aborted).toBe(false);
+		expect(expectCallArgs(spy, 0)[1]).toBe(123);
 
 		const finalValue = expectResultValue(result);
 		expect(finalValue[0]).toStrictEqual({
@@ -77,7 +77,7 @@ describe('useAsyncAbortable', () => {
 		const value = expectResultValue(result);
 		value[1].abort();
 
-		expect(spy.mock.calls[0][0].aborted).toBe(true);
+		expect(expectCallArgs(spy, 0)[0].aborted).toBe(true);
 
 		await act(async () => {
 			if (resolve.current) {
@@ -100,7 +100,7 @@ describe('useAsyncAbortable', () => {
 			value[1].reset();
 		});
 
-		expect(spy.mock.calls[0][0].aborted).toBe(true);
+		expect(expectCallArgs(spy, 0)[0].aborted).toBe(true);
 
 		const value = expectResultValue(result);
 		expect(value[0]).toStrictEqual({
@@ -132,11 +132,11 @@ describe('useAsyncAbortable', () => {
 			void value[1].execute(1234);
 		});
 
-		expect(spy.mock.calls[0][1]).toBe(123);
-		expect(spy.mock.calls[0][0].aborted).toBe(true);
+		expect(expectCallArgs(spy, 0)[1]).toBe(123);
+		expect(expectCallArgs(spy, 0)[0].aborted).toBe(true);
 
-		expect(spy.mock.calls[1][1]).toBe(1234);
-		expect(spy.mock.calls[1][0].aborted).toBe(false);
+		expect(expectCallArgs(spy, 1)[1]).toBe(1234);
+		expect(expectCallArgs(spy, 1)[0].aborted).toBe(false);
 
 		await act(async () => {
 			if (resolve1) {

--- a/src/useConditionalEffect/index.dom.test.ts
+++ b/src/useConditionalEffect/index.dom.test.ts
@@ -2,6 +2,7 @@ import {renderHook} from '@ver0/react-hooks-testing';
 import type {DependencyList, EffectCallback} from 'react';
 import {describe, expect, it, vi} from 'vitest';
 import {truthyAndArrayPredicate, truthyOrArrayPredicate, useConditionalEffect, useUpdateEffect} from '../index.js';
+import {expectCallArgs} from '../util/testing/test-helpers.js';
 
 describe('useConditionalEffect', () => {
 	it('should be defined', async () => {
@@ -119,7 +120,7 @@ describe('useConditionalEffect', () => {
 
 		expect(callbackSpy).not.toHaveBeenCalled();
 		expect(effectSpy).toHaveBeenCalledTimes(1);
-		expect(effectSpy.mock.calls[0][2]).toBe(123);
+		expect(expectCallArgs(effectSpy, 0)[2]).toBe(123);
 		await rerender();
 
 		expect(callbackSpy).toHaveBeenCalledTimes(1);

--- a/src/useCustomCompareEffect/index.dom.test.ts
+++ b/src/useCustomCompareEffect/index.dom.test.ts
@@ -3,6 +3,7 @@ import type {DependencyList} from 'react';
 import {describe, expect, it, vi} from 'vitest';
 import type {EffectCallback} from '../index.js';
 import {useCustomCompareEffect, useUpdateEffect} from '../index.js';
+import {expectCallArgs} from '../util/testing/test-helpers.js';
 
 describe('useCustomCompareEffect', () => {
 	it('should be defined', async () => {
@@ -35,8 +36,8 @@ describe('useCustomCompareEffect', () => {
 		await rerender({deps: [1, 3]});
 
 		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy.mock.calls[0][0]).toStrictEqual([1, 2]);
-		expect(spy.mock.calls[0][1]).toStrictEqual([1, 3]);
+		expect(expectCallArgs(spy, 0)[0]).toStrictEqual([1, 2]);
+		expect(expectCallArgs(spy, 0)[1]).toStrictEqual([1, 3]);
 	});
 
 	it('should not pass new deps to underlying effect only if comparator reported unequal deps', async () => {
@@ -50,14 +51,14 @@ describe('useCustomCompareEffect', () => {
 		await rerender({deps: [1, 2]});
 
 		expect(spy).toHaveBeenCalledTimes(2);
-		expect(spy.mock.calls[0][1]).toStrictEqual([1, 2]);
-		expect(spy.mock.calls[0][1]).toBe(spy.mock.calls[1][1]);
+		expect(expectCallArgs(spy, 0)[1]).toStrictEqual([1, 2]);
+		expect(expectCallArgs(spy, 0)[1]).toBe(expectCallArgs(spy, 1)[1]);
 
 		await rerender({deps: [1, 3]});
 
 		expect(spy).toHaveBeenCalledTimes(3);
-		expect(spy.mock.calls[2][1]).toStrictEqual([1, 3]);
-		expect(spy.mock.calls[0][1]).not.toBe(spy.mock.calls[2][1]);
+		expect(expectCallArgs(spy, 2)[1]).toStrictEqual([1, 3]);
+		expect(expectCallArgs(spy, 0)[1]).not.toBe(expectCallArgs(spy, 2)[1]);
 	});
 
 	it('should pass res argument to underlying hook', async () => {
@@ -76,12 +77,12 @@ describe('useCustomCompareEffect', () => {
 		// The spy should be called once on initial render
 		expect(spy).toHaveBeenCalledTimes(1);
 		expect(spy.mock.calls[0]).toHaveLength(3);
-		expect(spy.mock.calls[0][2]).toBe(123);
+		expect(expectCallArgs(spy, 0)[2]).toBe(123);
 
 		// Trigger a rerender to make sure the hook works properly
 		await rerender({deps: [1, 3]});
 
 		expect(spy).toHaveBeenCalledTimes(2);
-		expect(spy.mock.calls[1][2]).toBe(123);
+		expect(expectCallArgs(spy, 1)[2]).toBe(123);
 	});
 });

--- a/src/useCustomCompareMemo/index.dom.test.ts
+++ b/src/useCustomCompareMemo/index.dom.test.ts
@@ -47,7 +47,7 @@ describe('useCustomCompareMemo', () => {
 				useCustomCompareMemo(
 					() => user,
 					[user],
-					(savedDeps, deps) => savedDeps[0].name === deps[0].name,
+					(savedDeps, deps) => savedDeps[0]?.name === deps[0]?.name,
 				),
 			{initialProps: {user: mockUser}},
 		);

--- a/src/useDeepCompareMemo/index.ts
+++ b/src/useDeepCompareMemo/index.ts
@@ -10,6 +10,6 @@ import {useCustomCompareMemo} from '../useCustomCompareMemo/index.js';
  * @returns Initially returns the result of calling `factory`. On subsequent renders, it will return
  * the same value, if dependencies haven't changed, or the result of calling `factory` again, if they have changed.
  */
-export function useDeepCompareMemo<T, Deps extends DependencyList>(factory: () => T, deps: Deps) {
+export function useDeepCompareMemo<T, Deps extends DependencyList>(factory: () => T, deps: Deps): T {
 	return useCustomCompareMemo(factory, deps, isEqual);
 }

--- a/src/useEventListener/index.dom.test.ts
+++ b/src/useEventListener/index.dom.test.ts
@@ -1,6 +1,7 @@
 import {renderHook} from '@ver0/react-hooks-testing';
 import {describe, expect, it, vi} from 'vitest';
 import {useEventListener} from '../index.js';
+import {expectCallArgs} from '../util/testing/test-helpers.js';
 
 describe('useEventListener', () => {
 	it('should be defined', async () => {
@@ -45,7 +46,7 @@ describe('useEventListener', () => {
 		});
 
 		expect(addSpy).toHaveBeenCalledTimes(1);
-		expect(addSpy.mock.calls[0][2]).toStrictEqual({passive: true});
+		expect(expectCallArgs(addSpy, 0)[2]).toStrictEqual({passive: true});
 		expect(removeSpy).toHaveBeenCalledTimes(0);
 		await rerender();
 		expect(addSpy).toHaveBeenCalledTimes(1);

--- a/src/useIntersectionObserver/index.dom.test.ts
+++ b/src/useIntersectionObserver/index.dom.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook} from '@ver0/react-hooks-testing';
 import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 import {useIntersectionObserver} from '../index.js';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectResultValue} from '../util/testing/test-helpers.js';
 
 describe('useIntersectionObserver', () => {
 	// A function declaration keeps the mock constructable -- vitest 4 mocks
@@ -76,8 +76,8 @@ describe('useIntersectionObserver', () => {
 		const entry2 = {target: div2} as unknown as IntersectionObserverEntry;
 
 		await act(async () => {
-			IntersectionObserverMock.mock.calls[0][0]([entry1]);
-			IntersectionObserverMock.mock.calls[1][0]([entry2]);
+			expectCallArgs(IntersectionObserverMock, 0)[0]([entry1]);
+			expectCallArgs(IntersectionObserverMock, 1)[0]([entry2]);
 			vi.runAllTimers();
 		});
 
@@ -91,7 +91,7 @@ describe('useIntersectionObserver', () => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 		const entry3 = {target: div1} as unknown as IntersectionObserverEntry;
 		await act(async () => {
-			IntersectionObserverMock.mock.calls[0][0]([entry3]);
+			expectCallArgs(IntersectionObserverMock, 0)[0]([entry3]);
 			vi.runAllTimers();
 		});
 
@@ -122,7 +122,7 @@ describe('useIntersectionObserver', () => {
 		await act(async () => {
 			const lastCallIndex = IntersectionObserverMock.mock.calls.length - 1;
 			if (lastCallIndex >= 0) {
-				IntersectionObserverMock.mock.calls[lastCallIndex][0]([entry1]);
+				expectCallArgs(IntersectionObserverMock, lastCallIndex)[0]([entry1]);
 				await vi.runAllTimersAsync();
 			}
 		});

--- a/src/useIntersectionObserver/index.ts
+++ b/src/useIntersectionObserver/index.ts
@@ -144,7 +144,9 @@ export function useIntersectionObserver<T extends Element>(
 
 		let subscribed = true;
 		const observerEntry = getObserverEntry({
-			root: r && 'current' in r ? r.current : r,
+			// `root` is optional, but under `exactOptionalPropertyTypes` it cannot
+			// receive an explicit `undefined` -- null selects the viewport just the same.
+			root: (r && 'current' in r ? r.current : r) ?? null,
 			rootMargin,
 			threshold,
 		});

--- a/src/useIsomorphicLayoutEffect/index.ts
+++ b/src/useIsomorphicLayoutEffect/index.ts
@@ -5,4 +5,4 @@ import {isBrowser} from '../util/const.js';
  * Alias for `useLayoutEffect` in browser, but for `useEffect` at server side. Helps to avoid
  * warning shown during SSR.
  */
-export const useIsomorphicLayoutEffect = isBrowser ? useLayoutEffect : useEffect;
+export const useIsomorphicLayoutEffect: typeof useLayoutEffect = isBrowser ? useLayoutEffect : useEffect;

--- a/src/useKeyboardEvent/index.dom.test.ts
+++ b/src/useKeyboardEvent/index.dom.test.ts
@@ -2,6 +2,7 @@ import {renderHook} from '@ver0/react-hooks-testing';
 import {describe, expect, it, vi} from 'vitest';
 import type {KeyboardEventFilter} from '../index.js';
 import {useKeyboardEvent} from '../index.js';
+import {expectCallArgs} from '../util/testing/test-helpers.js';
 
 describe('useKeyboardEvent', () => {
 	it('should be defined', async () => {
@@ -56,7 +57,7 @@ describe('useKeyboardEvent', () => {
 		});
 
 		expect(addSpy).toHaveBeenCalledTimes(1);
-		expect(addSpy.mock.calls[0][2]).toStrictEqual({passive: true});
+		expect(expectCallArgs(addSpy, 0)[2]).toStrictEqual({passive: true});
 		expect(removeSpy).toHaveBeenCalledTimes(0);
 		await rerender();
 		expect(addSpy).toHaveBeenCalledTimes(1);

--- a/src/useList/index.dom.test.ts
+++ b/src/useList/index.dom.test.ts
@@ -3,7 +3,7 @@ import {act, renderHook} from '@ver0/react-hooks-testing';
 import type {Mock} from 'vitest';
 import {describe, expect, it, vi} from 'vitest';
 import {useList} from '../index.js';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectResultValue} from '../util/testing/test-helpers.js';
 
 describe('useList', () => {
 	it('should be defined', async () => {
@@ -414,5 +414,5 @@ function numberOfMockFunctionCalls(mockFunction: Mock): number {
 
 function mockFunctionCallArgument(mockFunction: Mock, callIndex: number, argumentIndex: number) {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return mockFunction.mock.calls[callIndex][argumentIndex];
+	return expectCallArgs(mockFunction, callIndex)[argumentIndex];
 }

--- a/src/useMeasure/index.dom.test.ts
+++ b/src/useMeasure/index.dom.test.ts
@@ -2,7 +2,7 @@ import {act, renderHook} from '@ver0/react-hooks-testing';
 import {useEffect} from 'react';
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 import {borderBoxMeasurer, useMeasure} from '../index.js';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectResultValue} from '../util/testing/test-helpers.js';
 
 describe('useMeasure', () => {
 	const observeSpy = vi.fn();
@@ -104,7 +104,7 @@ describe('useMeasure', () => {
 			contentBoxSize: {},
 		} as unknown as ResizeObserverEntry;
 
-		ResizeObserverSpy.mock.calls[0][0]([entry]);
+		expectCallArgs(ResizeObserverSpy, 0)[0]([entry]);
 		let value = expectResultValue(result);
 		expect(value[0]).toBeUndefined();
 
@@ -137,7 +137,7 @@ describe('useMeasure', () => {
 			contentBoxSize: {},
 		} as unknown as ResizeObserverEntry;
 
-		ResizeObserverSpy.mock.calls[0][0]([entry]);
+		expectCallArgs(ResizeObserverSpy, 0)[0]([entry]);
 
 		await act(async () => {
 			vi.advanceTimersByTime(1);

--- a/src/useMeasure/index.ts
+++ b/src/useMeasure/index.ts
@@ -28,10 +28,13 @@ export const contentBoxMeasurer: Measurer = (entry) => ({
  * Border box sizes are writing-mode relative, so `inlineSize` maps to width and `blockSize` to
  * height only in horizontal writing modes.
  */
-export const borderBoxMeasurer: Measurer = (entry) => ({
-	width: entry.borderBoxSize[0].inlineSize,
-	height: entry.borderBoxSize[0].blockSize,
-});
+export const borderBoxMeasurer: Measurer = (entry) => {
+	// The array exists for future multi-fragment support; observing an element
+	// always reports exactly one border box size.
+	const size = entry.borderBoxSize[0]!;
+
+	return {width: size.inlineSize, height: size.blockSize};
+};
 
 /**
  * Uses ResizeObserver to track element dimensions and re-render component when they change.

--- a/src/useMediaQuery/index.dom.test.ts
+++ b/src/useMediaQuery/index.dom.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook} from '@ver0/react-hooks-testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {useMediaQuery} from '../index.js';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectCallResult, expectResultValue} from '../util/testing/test-helpers.js';
 
 describe('useMediaQuery', () => {
 	const matchMediaMock = vi.fn((query: string) => ({
@@ -53,17 +53,18 @@ describe('useMediaQuery', () => {
 		const {result} = await renderHook(() => useMediaQuery('max-width : 768px'));
 		expect(result.value).toBe(false);
 
-		expect(matchMediaMock.mock.results[0].type).toEqual('return');
-		if (matchMediaMock.mock.results[0].type !== 'return') {
+		const mockResult = expectCallResult(matchMediaMock, 0);
+		expect(mockResult.type).toEqual('return');
+		if (mockResult.type !== 'return') {
 			return;
 		}
 
-		const mql = matchMediaMock.mock.results[0].value;
+		const mql = mockResult.value;
 		mql.matches = true;
 
 		await act(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			mql.addEventListener.mock.calls[0][1]();
+			expectCallArgs(mql.addEventListener, 0)[1]();
 		});
 		expect(result.value).toBe(true);
 	});
@@ -76,17 +77,18 @@ describe('useMediaQuery', () => {
 		expect(result2.value).toBe(false);
 		expect(result3.value).toBe(false);
 
-		expect(matchMediaMock.mock.results[0].type).toEqual('return');
-		if (matchMediaMock.mock.results[0].type !== 'return') {
+		const mockResult = expectCallResult(matchMediaMock, 0);
+		expect(mockResult.type).toEqual('return');
+		if (mockResult.type !== 'return') {
 			return;
 		}
 
-		const mql = matchMediaMock.mock.results[0].value;
+		const mql = mockResult.value;
 		mql.matches = true;
 
 		await act(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			mql.addEventListener.mock.calls[0][1]();
+			expectCallArgs(mql.addEventListener, 0)[1]();
 		});
 		expect(result1.value).toBe(true);
 		expect(result2.value).toBe(true);
@@ -107,17 +109,18 @@ describe('useMediaQuery', () => {
 
 		expect(matchMediaMock).toHaveBeenCalledTimes(2);
 
-		expect(matchMediaMock.mock.results[0].type).toEqual('return');
-		if (matchMediaMock.mock.results[0].type !== 'return') {
+		const mockResult = expectCallResult(matchMediaMock, 0);
+		expect(mockResult.type).toEqual('return');
+		if (mockResult.type !== 'return') {
 			return;
 		}
 
-		const mql = matchMediaMock.mock.results[0].value;
+		const mql = mockResult.value;
 		mql.matches = true;
 
 		await act(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			mql.addEventListener.mock.calls[0][1]();
+			expectCallArgs(mql.addEventListener, 0)[1]();
 		});
 		expect(result1.value).toBe(true);
 		expect(result2.value).toBe(true);
@@ -129,12 +132,13 @@ describe('useMediaQuery', () => {
 		const {unmount: unmount2} = await renderHook(() => useMediaQuery('max-width : 768px'));
 		const {unmount: unmount3} = await renderHook(() => useMediaQuery('max-width : 768px'));
 
-		expect(matchMediaMock.mock.results[0].type).toEqual('return');
-		if (matchMediaMock.mock.results[0].type !== 'return') {
+		const mockResult = expectCallResult(matchMediaMock, 0);
+		expect(mockResult.type).toEqual('return');
+		if (mockResult.type !== 'return') {
 			return;
 		}
 
-		const mql = matchMediaMock.mock.results[0].value;
+		const mql = mockResult.value;
 		expect(mql.removeEventListener).not.toHaveBeenCalled();
 		await unmount3();
 		expect(mql.removeEventListener).not.toHaveBeenCalled();

--- a/src/useQueue/index.dom.test.ts
+++ b/src/useQueue/index.dom.test.ts
@@ -32,6 +32,17 @@ describe('useQueue', () => {
 		expect(value.first).toBe(1);
 	});
 
+	it('should return undefined removing from an empty queue', async () => {
+		const {result} = await renderHook(() => useQueue<number>());
+		const value = expectResultValue(result);
+
+		await act(async () => {
+			expect(value.remove()).toBeUndefined();
+		});
+
+		expect(expectResultValue(result).items).toStrictEqual([]);
+	});
+
 	it('should return the length', async () => {
 		const {result} = await renderHook(() => useQueue([0, 1, 2, 3]));
 		const value = expectResultValue(result);

--- a/src/useQueue/index.ts
+++ b/src/useQueue/index.ts
@@ -45,7 +45,9 @@ export function useQueue<T>(initialValue: T[] = []): QueueMethods<T> {
 				push(value);
 			},
 			remove() {
-				const value = listRef.current[0];
+				// `QueueMethods.remove` promises `T`, yet an empty queue has always
+				// returned `undefined` here -- the public type hides that.
+				const value = listRef.current[0]!;
 
 				removeAt(0);
 

--- a/src/useQueue/index.ts
+++ b/src/useQueue/index.ts
@@ -21,9 +21,9 @@ export type QueueMethods<T> = {
 	 */
 	add: (item: T) => void;
 	/**
-	 * Removes and returns the head of the queue.
+	 * Removes and returns the head of the queue, or `undefined` if it is empty.
 	 */
-	remove: () => T;
+	remove: () => T | undefined;
 	/**
 	 * The current size of the queue.
 	 */
@@ -45,9 +45,7 @@ export function useQueue<T>(initialValue: T[] = []): QueueMethods<T> {
 				push(value);
 			},
 			remove() {
-				// `QueueMethods.remove` promises `T`, yet an empty queue has always
-				// returned `undefined` here -- the public type hides that.
-				const value = listRef.current[0]!;
+				const value = listRef.current[0];
 
 				removeAt(0);
 

--- a/src/useResizeObserver/index.dom.test.ts
+++ b/src/useResizeObserver/index.dom.test.ts
@@ -2,6 +2,7 @@ import type {RefObject} from 'react';
 import {renderHook} from '@ver0/react-hooks-testing';
 import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 import {useResizeObserver} from '../index.js';
+import {expectCallArgs} from '../util/testing/test-helpers.js';
 
 describe('useResizeObserver', () => {
 	const observeSpy = vi.fn();
@@ -91,7 +92,7 @@ describe('useResizeObserver', () => {
 			contentBoxSize: {},
 		} as unknown as ResizeObserverEntry;
 
-		ResizeObserverSpy.mock.calls[0][0]([entry]);
+		expectCallArgs(ResizeObserverSpy, 0)[0]([entry]);
 
 		expect(spy).not.toHaveBeenCalledWith(entry);
 
@@ -122,7 +123,7 @@ describe('useResizeObserver', () => {
 			contentBoxSize: {},
 		} as unknown as ResizeObserverEntry;
 
-		ResizeObserverSpy.mock.calls[0][0]([entry]);
+		expectCallArgs(ResizeObserverSpy, 0)[0]([entry]);
 
 		expect(spy1).not.toHaveBeenCalledWith(entry);
 		expect(spy2).not.toHaveBeenCalledWith(entry);
@@ -163,7 +164,7 @@ describe('useResizeObserver', () => {
 			contentBoxSize: {},
 		} as unknown as ResizeObserverEntry;
 
-		ResizeObserverSpy.mock.calls[0][0]([entry1, entry2]);
+		expectCallArgs(ResizeObserverSpy, 0)[0]([entry1, entry2]);
 
 		expect(spy1).not.toHaveBeenCalledWith(entry1);
 		expect(spy2).not.toHaveBeenCalledWith(entry2);

--- a/src/useScreenOrientation/index.dom.test.ts
+++ b/src/useScreenOrientation/index.dom.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook} from '@ver0/react-hooks-testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {useScreenOrientation} from '../index.js';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectCallResult, expectResultValue} from '../util/testing/test-helpers.js';
 
 describe('useScreenOrientation', () => {
 	const matchMediaMock = vi.fn((query: string) => ({
@@ -41,17 +41,18 @@ describe('useScreenOrientation', () => {
 		const {result} = await renderHook(() => useScreenOrientation());
 		expect(result.value).toBe('landscape');
 
-		expect(matchMediaMock.mock.results[0].type).toEqual('return');
-		if (matchMediaMock.mock.results[0].type !== 'return') {
+		const mockResult = expectCallResult(matchMediaMock, 0);
+		expect(mockResult.type).toEqual('return');
+		if (mockResult.type !== 'return') {
 			return;
 		}
 
-		const mql = matchMediaMock.mock.results[0].value;
+		const mql = mockResult.value;
 		mql.matches = true;
 
 		await act(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			mql.addEventListener.mock.calls[0][1]();
+			expectCallArgs(mql.addEventListener, 0)[1]();
 		});
 
 		expect(result.value).toBe('portrait');

--- a/src/useStorageValue/index.dom.test.ts
+++ b/src/useStorageValue/index.dom.test.ts
@@ -1,6 +1,6 @@
 import {act, renderHook} from '@ver0/react-hooks-testing';
 import {describe, expect, it, vi} from 'vitest';
-import {expectResultValue} from '../util/testing/test-helpers.js';
+import {expectCallArgs, expectResultValue} from '../util/testing/test-helpers.js';
 import {newStorage} from './misc.test.js';
 import {useStorageValue} from './index.js';
 
@@ -79,7 +79,7 @@ describe('useStorageValue', () => {
 
 		const value = expectResultValue(result);
 		expect(value.value).toBe('defaultValue');
-		expect(warnSpy.mock.calls[0][0]).toBeInstanceOf(SyntaxError);
+		expect(expectCallArgs(warnSpy, 0)[0]).toBeInstanceOf(SyntaxError);
 
 		warnSpy.mockRestore();
 	});

--- a/src/useVibrate/index.dom.test.ts
+++ b/src/useVibrate/index.dom.test.ts
@@ -1,6 +1,7 @@
 import {renderHook} from '@ver0/react-hooks-testing';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {useVibrate} from '../index.js';
+import {expectCallArgs} from '../util/testing/test-helpers.js';
 
 describe('useVibrate', () => {
 	// Use the global vibrate mock that's already set up in the test environment
@@ -27,7 +28,7 @@ describe('useVibrate', () => {
 			useVibrate(true, [100, 200]);
 		});
 		expect(vibrateMock).toHaveBeenCalledTimes(1);
-		expect(vibrateMock.mock.calls[0][0]).toEqual([100, 200]);
+		expect(expectCallArgs(vibrateMock, 0)[0]).toEqual([100, 200]);
 	});
 
 	it('should call navigator.vibrate(0) on unmount', async () => {
@@ -37,7 +38,7 @@ describe('useVibrate', () => {
 
 		await unmount();
 
-		expect(vibrateMock.mock.calls[1][0]).toEqual(0);
+		expect(expectCallArgs(vibrateMock, 1)[0]).toEqual(0);
 	});
 
 	it('should vibrate constantly using interval', async () => {
@@ -48,18 +49,18 @@ describe('useVibrate', () => {
 		});
 
 		expect(vibrateMock).toHaveBeenCalledTimes(1);
-		expect(vibrateMock.mock.calls[0][0]).toEqual(300);
+		expect(expectCallArgs(vibrateMock, 0)[0]).toEqual(300);
 
 		vi.advanceTimersByTime(299);
 		expect(vibrateMock).toHaveBeenCalledTimes(1);
 
 		vi.advanceTimersByTime(1);
 		expect(vibrateMock).toHaveBeenCalledTimes(2);
-		expect(vibrateMock.mock.calls[1][0]).toEqual(300);
+		expect(expectCallArgs(vibrateMock, 1)[0]).toEqual(300);
 
 		vi.advanceTimersByTime(300);
 		expect(vibrateMock).toHaveBeenCalledTimes(3);
-		expect(vibrateMock.mock.calls[2][0]).toEqual(300);
+		expect(expectCallArgs(vibrateMock, 2)[0]).toEqual(300);
 
 		vi.useRealTimers();
 	});

--- a/src/useVibrate/index.ts
+++ b/src/useVibrate/index.ts
@@ -8,7 +8,7 @@ import {isBrowser, noop} from '../util/const.js';
  * @param pattern VibrationPattern passed down to `navigator.vibrate`.
  * @param loop If true - vibration will be looped using `setInterval`.
  */
-export const useVibrate =
+export const useVibrate: (enabled: boolean, pattern: VibratePattern, loop?: boolean) => void =
 	!isBrowser || navigator.vibrate === undefined
 		? noop
 		: (enabled: boolean, pattern: VibratePattern, loop?: boolean): void => {

--- a/src/useWindowSize/index.ts
+++ b/src/useWindowSize/index.ts
@@ -28,7 +28,7 @@ const callAllListeners = () => {
   stage, after the component has mounted. If `false`, the window size is measured synchronously during
   the component render. Set this to `true` during SSR.
  */
-export function useWindowSize(stateHook = useRafState, measureOnMount?: boolean): WindowSize {
+export function useWindowSize(stateHook: typeof useRafState = useRafState, measureOnMount?: boolean): WindowSize {
 	const isFirstMount = useFirstMountState();
 	const [size, setSize] = stateHook<WindowSize>({
 		width: isFirstMount && isBrowser && measureOnMount !== true ? window.innerWidth : 0,

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -4,7 +4,7 @@ export const noop = (): void => {
 	/* noop */
 };
 
-export const isBrowser =
+export const isBrowser: boolean =
 	typeof globalThis !== 'undefined' && typeof navigator !== 'undefined' && typeof document !== 'undefined';
 
 /**

--- a/src/util/process-env.d.ts
+++ b/src/util/process-env.d.ts
@@ -1,0 +1,4 @@
+// Development-only warnings are guarded by `process.env.NODE_ENV`, which every
+// bundler replaces at build time. Declaring the single field the sources touch
+// keeps @types/node out of the browser build and off consumers' type surface.
+declare const process: {readonly env: {readonly NODE_ENV?: string}};

--- a/src/util/resolve-hook-state.ts
+++ b/src/util/resolve-hook-state.ts
@@ -27,7 +27,7 @@ function updateState<State, PreviousState = State>(
 
 export function resolveHookState<State, PreviousState = State>(
 	...args: Parameters<typeof initState<State>> | Parameters<typeof updateState<State, PreviousState>>
-) {
+): State {
 	if (args.length === 1) {
 		return initState(args[0]);
 	}

--- a/src/util/testing/test-helpers.ts
+++ b/src/util/testing/test-helpers.ts
@@ -3,10 +3,38 @@ import {expect} from 'vitest';
 
 /**
  * Helper to assert that a hook result is successful and extract its value.
+ *
+ * Accepts `undefined` so that indexed renders (`result.all[i]`) can be passed
+ * straight in -- a missing render fails the assertion instead of the type check.
  */
-export function expectResultValue<T>(result: ResultValue<T>) {
-	expect(result.error).toBeUndefined();
+export function expectResultValue<T>(result: ResultValue<T> | undefined): T {
+	expect(result).toBeDefined();
+	expect(result?.error).toBeUndefined();
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-	return result.value as T;
+	return result?.value as T;
+}
+
+/**
+ * Helper to assert that a mock has produced a result for the given call and
+ * extract it.
+ */
+export function expectCallResult<Result>(mock: {mock: {results: Result[]}}, index = 0): Result {
+	const result = mock.mock.results[index];
+
+	expect(result).toBeDefined();
+
+	return result!;
+}
+
+/**
+ * Helper to assert that a mock has been called at least `index + 1` times and
+ * extract the arguments of that call.
+ */
+export function expectCallArgs<Args extends unknown[]>(mock: {mock: {calls: Args[]}}, index = 0): Args {
+	const call = mock.mock.calls[index];
+
+	expect(call).toBeDefined();
+
+	return call!;
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"noEmit": false,
 		"declaration": true,
+		"isolatedDeclarations": true,
 		"newLine": "lf",
 		"rootDir": "./src",
 		"outDir": "./dist"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,8 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"noEmit": false,
+		"declaration": true,
+		"newLine": "lf",
 		"rootDir": "./src",
 		"outDir": "./dist"
 	},

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,5 +6,5 @@
 		"outDir": "./dist"
 	},
 	"include": ["./src"],
-	"exclude": ["./src/**/*.test.ts"]
+	"exclude": ["./src/**/*.test.ts", "./src/util/testing"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,11 @@
 		"moduleResolution": "NodeNext",
 		"jsx": "react-jsx",
 		"lib": ["ESNext", "DOM"],
+		"types": [],
 		"declaration": true,
 		"newLine": "lf",
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,
-		"skipLibCheck": true,
-		"types": ["node"]
+		"skipLibCheck": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
+		"noUncheckedIndexedAccess": true,
 		"exactOptionalPropertyTypes": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,21 @@
 		"target": "ESNext",
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
+		"moduleDetection": "force",
 		"jsx": "react-jsx",
 		"lib": ["ESNext", "DOM"],
 		"types": [],
-		"declaration": true,
-		"newLine": "lf",
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"erasableSyntaxOnly": true,
 		"forceConsistentCasingInFileNames": true,
+		"skipLibCheck": true,
 		"strict": true,
-		"skipLibCheck": true
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"exactOptionalPropertyTypes": true
 	}
 }

--- a/types/ver0-oxlint-config.d.ts
+++ b/types/ver0-oxlint-config.d.ts
@@ -1,9 +1,0 @@
-// @ver0/oxlint-config ships plain JS presets without declarations, so every
-// preset import resolves to `any` and poisons the lint config in vite.config.ts.
-declare module '@ver0/oxlint-config/*' {
-	import type {OxlintConfig} from 'oxlint';
-
-	const config: OxlintConfig;
-
-	export default config;
-}

--- a/types/ver0-oxlint-config.d.ts
+++ b/types/ver0-oxlint-config.d.ts
@@ -1,0 +1,9 @@
+// @ver0/oxlint-config ships plain JS presets without declarations, so every
+// preset import resolves to `any` and poisons the lint config in vite.config.ts.
+declare module '@ver0/oxlint-config/*' {
+	import type {OxlintConfig} from 'oxlint';
+
+	const config: OxlintConfig;
+
+	export default config;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import type {OxlintConfig} from 'oxlint';
 import {defineConfig} from 'vite-plus';
 import javascript from '@ver0/oxlint-config/javascript.js';
 import typescript from '@ver0/oxlint-config/typescript.js';
@@ -6,7 +7,7 @@ import browser from '@ver0/oxlint-config/browser.js';
 import vitest from '@ver0/oxlint-config/vitest.js';
 
 // Composed via extends after the presets so these overrides apply last.
-const repoOverrides = {
+const repoOverrides: OxlintConfig = {
 	rules: {
 		// Hook parameters are inherently mutable platform types
 		// (DOM elements, React refs, dependency lists).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,7 @@ export default defineConfig({
 		],
 	},
 	lint: {
+		options: {typeCheck: true},
 		extends: [javascript, typescript, react, browser, vitest, repoOverrides],
 		ignorePatterns: ['.claude', '.idea', 'dist', 'coverage', 'CHANGELOG.md'],
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,7 +1096,7 @@ __metadata:
     "@types/react": "npm:^19.2.17"
     "@types/react-dom": "npm:^19.2.3"
     "@ver0/deep-equal": "npm:^2.0.1"
-    "@ver0/oxlint-config": "npm:^2.0.0"
+    "@ver0/oxlint-config": "npm:^2.0.2"
     "@ver0/react-hooks-testing": "npm:^1.0.3"
     "@vitest/coverage-v8": "npm:^4.1.10"
     js-cookie: "npm:^3.0.8"
@@ -1686,15 +1686,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ver0/oxlint-config@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@ver0/oxlint-config@npm:2.0.0"
+"@ver0/oxlint-config@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@ver0/oxlint-config@npm:2.0.2"
   peerDependencies:
     oxlint: ^1.75.0
   peerDependenciesMeta:
     oxlint:
       optional: true
-  checksum: 10c0/9d10a276cf44c9ff4f70ddfb8c2ce76f7a5538ccf43e1d9179f57a2bb04415b0e436c858799697bc0f8662227937b5d9e74e0a75cf4ddf57a56237a98cc148da
+  checksum: 10c0/d6e8b981ef1fdc269251dfff76ab98a842d2e6c20a542330d98559a5406b208d1656435da1330928b9a6df3cb3a2e4fa4c7450a7d6a77f64c39326ee0d4adfdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Revision of the whole TypeScript setup now that the toolchain runs the TS 7 native compiler. Eight atomic commits, each green on its own.

### Published-output fixes

- **`fix(build)`: test helpers left the package.** `src/util/testing/test-helpers.ts` is not a `*.test.ts` file, so the build emitted it and the `./*` export map published `@react-hookz/web/util/testing/test-helpers.js` — an importable subpath that pulls in `vitest`, which consumers do not have. Tarball drops from 131 to 129 entries.
- **`fix(useQueue)!`: `remove()` is typed `T | undefined`.** Removing from an empty queue has always returned `undefined`; the old `T` signature hid it. Runtime unchanged, so this is a type-level break only — **cuts a major release**.

### Compiler options

`tsconfig.json` now enables what the repo's own TypeScript rules ask for, plus module hygiene:

| Option | Cost to adopt |
|---|---|
| `noUncheckedIndexedAccess` | 73 errors — 70 in tests, 3 in sources |
| `exactOptionalPropertyTypes` | 1 — intersection observer passed an explicit `undefined` root, normalised to `null` |
| `noUnusedParameters` | 1 — unused mock parameter |
| `moduleDetection`, `isolatedModules`, `verbatimModuleSyntax`, `erasableSyntaxOnly`, `noImplicitOverride`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals` | 0 — already satisfied |
| `isolatedDeclarations` (build config) | 6 annotations, all copied from the declarations tsc already emitted |

The 70 test errors are absorbed by two new helpers next to `expectResultValue` — `expectCallArgs` and `expectCallResult` — so a missing call, result or render fails an assertion instead of the type check.

Rejected: `noPropertyAccessFromIndexSignature`. It forces `process.env['NODE_ENV']`, and bundlers pattern-match the dot form for dead-code elimination.

### Type surface

- `types: []` — the only thing pulling `@types/node` into a browser library was four dev-only `process.env.NODE_ENV` warnings; that single field is now declared locally.
- `@ver0/oxlint-config` 2.0.0 shipped JS presets with no declarations, so every preset import resolved to `any` (5× TS7016) and `tsc --noEmit` was red before this PR. Bumped to 2.0.2, which ships a `.d.ts` beside every preset. The local override block still needs its `OxlintConfig` annotation — untyped, its rule values widen to `string` and `plugins` to `string[]`.
- Emit-only options (`declaration`, `newLine`) moved to `tsconfig.build.json`, where they actually apply.

### Type checking now covers tests

Nothing verified test-file types: `build` compiles `tsconfig.build.json`, which excludes them. `lint.options.typeCheck` makes tsgolint report tsc diagnostics for everything the lint config sees, so the existing CI lint job covers them at ~1.5s; `yarn typecheck` runs the same check standalone.

### Verification

`fmt:check`, `typecheck`, `lint`, `build` all exit 0; 117 test files / 529 tests pass. Rebuilt `dist` has **zero `.d.ts` differences** apart from the deliberate `useQueue.remove` change, and the only `.js` differences are the three intended source edits.
