### PR TITLE
fix(package): resolve extensionless hook subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can import hooks two ways:
 // from the root of package
 import {useMountEffect} from '@react-hookz/web';
 // or single hook directly
-import {useMountEffect} from '@react-hookz/web/useMountEffect/index.js';
+import {useMountEffect} from '@react-hookz/web/useMountEffect';
 ```
 
 In case your bundler supports tree-shaking (most of modern does) - both variants are equal and only necessary code will

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
 	"exports": {
 		".": "./dist/index.js",
 		"./package.json": "./package.json",
-		"./*/": "./dist/*/index.js",
-		"./*": "./dist/*"
+		"./*.js": "./dist/*.js",
+		"./*": "./dist/*/index.js",
+		"./*/": "./dist/*/index.js"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Fixes the subpath resolution problem found while reviewing #1670.

### Problem

```
$ node -e "import('@react-hookz/web/useToggle')"
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '.../dist/useToggle' is not supported
```

`"./*": "./dist/*"` maps `useToggle` onto a directory, so the natural extensionless specifier has never worked — only the `useToggle/index.js` form the README documented, or the `useToggle/` trailing-slash form, which Node warns about:

```
DeprecationWarning: Use of deprecated trailing slash pattern mapping "./useToggle/" ...
Mapping specifiers ending in "/" is no longer supported. (DEP0155)
```

### Change

```diff
 "exports": {
   ".": "./dist/index.js",
   "./package.json": "./package.json",
-  "./*/": "./dist/*/index.js",
-  "./*": "./dist/*"
+  "./*.js": "./dist/*.js",
+  "./*": "./dist/*/index.js",
+  "./*/": "./dist/*/index.js"
 }
```

`./*` now targets the directory's entry file, and `./*.js` preserves explicit file paths — its `*` matches slashes, so `useToggle/index.js` still lands on `dist/useToggle/index.js`. Exact keys and pattern specificity ordering are handled by Node, not by key order.

`./*/` is kept deliberately. It is deprecated, but it is the only form that worked for people who wanted a directory-style import, and dropping it would break them for no gain — it warns only when used.

Purely additive: every specifier that resolved before resolves to the same file.

### Verification

Packed the tarball, installed it into a scratch consumer with react 19, and resolved each form (Node 26):

| Specifier | Before | After |
|---|---|---|
| `@react-hookz/web` | ok | ok, 62 exports |
| `@react-hookz/web/useToggle` | **ERR_UNSUPPORTED_DIR_IMPORT** | ok |
| `@react-hookz/web/useToggle/index.js` | ok | ok |
| `@react-hookz/web/useMeasure` | **ERR_UNSUPPORTED_DIR_IMPORT** | ok, 3 exports |
| `@react-hookz/web/types.js` | ok | ok |
| `@react-hookz/web/util/const.js` | ok | ok |
| `@react-hookz/web/package.json` | ok | ok |
| `@react-hookz/web/useToggle/` | ok + DEP0155 | ok + DEP0155 |

Types follow the same map — `tsc` under `moduleResolution: NodeNext` accepts `import {useToggle} from '@react-hookz/web/useToggle'` and `import type {Measures} from '@react-hookz/web/useMeasure'` against the packed tarball (exit 0).

README's direct-import example switches to the short form.