### PR TITLE
ci: run the pipeline through vp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 'CI/CD'
+name: 'CI'
 
 on:
   push:
@@ -24,21 +24,25 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: 'Enable corepack'
-        run: corepack enable
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+
+      # setup-vp replaces corepack + setup-node + dependency cache: it installs
+      # vp (version resolved from the vite-plus range via yarn.lock), sets up
+      # Node and the pinned yarn, and caches the yarn store.
+      - name: 'Setup Vite+'
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
-          node-version: 24
-          cache: 'yarn'
+          node-version: '24'
+          cache: true
+          run-install: false
 
       - name: 'Install dependencies'
-        run: yarn install --immutable
+        run: vp install --frozen-lockfile
 
       - name: 'Format check'
-        run: yarn fmt:check
+        run: vp fmt --check
 
       - name: 'Lint'
-        run: yarn lint
+        run: vp lint
 
   build:
     name: 'Build'
@@ -48,18 +52,19 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: 'Enable corepack'
-        run: corepack enable
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+
+      - name: 'Setup Vite+'
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
-          node-version: 24
-          cache: 'yarn'
+          node-version: '24'
+          cache: true
+          run-install: false
 
       - name: 'Install dependencies'
-        run: yarn install --immutable
+        run: vp install --frozen-lockfile
 
       - name: 'Build'
-        run: yarn build
+        run: vp run build
 
   test:
     name: 'Test (Node ${{ matrix.node-version }})'
@@ -67,29 +72,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['lts/*']
+        node-version: ['lts']
     steps:
       - name: 'Checkout'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: 'Enable corepack'
-        run: corepack enable
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+
+      - name: 'Setup Vite+'
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+          cache: true
+          run-install: false
 
       - name: 'Install dependencies'
-        run: yarn install --immutable
+        run: vp install --frozen-lockfile
 
       - name: 'Test'
         run:
-          yarn test:coverage --reporter='github-actions' --reporter='junit'
+          vp test --run --coverage --reporter='github-actions' --reporter='junit'
           --outputFile='./coverage/test-report.junit.xml' --reporter=default
 
       - name: 'Upload coverage to Codecov'
-        if: ${{ matrix.node-version == 'lts/*' }}
+        if: ${{ matrix.node-version == 'lts' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -98,7 +104,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: 'Upload test results to Codecov'
-        if: ${{ !cancelled() && matrix.node-version == 'lts/*' }}
+        if: ${{ !cancelled() && matrix.node-version == 'lts' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: 'Release'
 
 on:
   workflow_run:
-    workflows: ['CI/CD']
+    workflows: ['CI']
     types: [completed]
     branches: [master]
   workflow_dispatch:
@@ -33,24 +33,24 @@ jobs:
           ref: 'master'
           # the job token is read-only; git push must use the GH_TOKEN PAT from env
           persist-credentials: false
-      - name: 'Enable corepack'
-        run: corepack enable
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: 'Setup Vite+'
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
-          node-version: 24
-          cache: 'yarn'
+          node-version: '24'
+          cache: true
+          run-install: false
 
       - name: 'Install dependencies'
-        run: yarn install --immutable
+        run: vp install --frozen-lockfile
 
       - name: 'Build'
-        run: yarn build
+        run: vp run build
 
       - name: 'Release'
         env:
           # PAT instead of GITHUB_TOKEN so the published release triggers the Discord workflow
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: yarn semantic-release
+        run: vp exec semantic-release
 
   gen-contributors:
     name: 'Generate Contributors List'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ vite.config.ts              # test, lint and format config, all three
 - Vitest 4, two projects split by filename: `*.dom.test.ts` runs in jsdom, `*.ssr.test.ts` in node.
 - yarn 4 via corepack, for dependency work only (`yarn up <pkg>`, `yarn install --immutable`).
 - semantic-release publishes from `master`; GitHub Actions are SHA-pinned via `pinact`.
+- CI goes through `vp` only: `voidzero-dev/setup-vp` provides Node, yarn, the dependency cache and the install, so no
+  `corepack enable`, no `actions/setup-node` and no direct `yarn` call belongs in a workflow.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NPM Downloads](https://img.shields.io/npm/dm/%40react-hookz%2Fweb?style=flat-square)](https://www.npmjs.com/package/@react-hookz/web)
 [![Dependents](https://img.shields.io/librariesio/dependents/npm/%40react-hookz%2Fweb?style=flat-square)](https://www.npmjs.com/package/@react-hookz/web)
-[![Build](https://img.shields.io/github/actions/workflow/status/react-hookz/web/ci-cd.yml?branch=master&style=flat-square)](https://github.com/react-hookz/web/actions)
+[![Build](https://img.shields.io/github/actions/workflow/status/react-hookz/web/ci.yml?branch=master&style=flat-square)](https://github.com/react-hookz/web/actions)
 [![Coverage](https://img.shields.io/codecov/c/github/react-hookz/web?style=flat-square)](https://app.codecov.io/gh/react-hookz/web)
 
 × **[DISCORD](https://discord.gg/Fjwphtu65f)** × **[RELEASES](https://github.com/react-hookz/web/releases)** ×

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "yarn build:clean && tsc --version && tsc --project ./tsconfig.build.json",
-		"build:clean": "yarn rimraf ./dist",
+		"build": "vp run build:clean && tsc --version && tsc --project ./tsconfig.build.json",
+		"build:clean": "rimraf ./dist",
 		"fmt": "vp fmt --write",
 		"fmt:check": "vp fmt --check",
 		"lint": "vp lint",


### PR DESCRIPTION
## What

CI called `yarn` directly everywhere, even though the toolchain is Vite+. Every job now goes through `vp`, following the [Vite+ CI guide](https://viteplus.dev/guide/ci).

Per job, three steps collapse into one action plus an explicit install:

```yaml
- name: 'Setup Vite+'
  uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
  with:
    node-version: '24'
    cache: true
    run-install: false

- name: 'Install dependencies'
  run: vp install --frozen-lockfile
```

`corepack enable`, `actions/setup-node` and `cache: 'yarn'` are gone -- setup-vp covers Node, the pinned yarn and the dependency cache. No `version` input: it resolves the `vite-plus` range from `package.json` through `yarn.lock`, so the version stays pinned in one place.

Commands: `vp fmt --check`, `vp lint`, `vp run build`, `vp test --run --coverage ...`, and `vp exec semantic-release` in the release workflow.

## Two things beyond a find-replace

- **Test matrix `'lts/*'` -> `'lts'`.** setup-vp passes `node-version` to `vp env use`, which accepts `lts`, `latest` or a plain major, but not the nvm-style spec. Both Codecov `if:` conditions moved with it. Job display name becomes `Test (Node lts)`.
- **`package.json` build scripts shelled back into yarn** (`yarn build:clean`, `yarn rimraf`), so `vp run build` would have re-entered yarn anyway. `build:clean` calls `rimraf` directly.

## Workflow rename

`CI/CD` -> `CI`, `ci-cd.yml` -> `ci.yml`, now that releases live in `release.yml`. Two references had to follow, since `workflow_run` matches on the workflow's **name**, not its filename:

- `release.yml` -- `workflows: ['CI/CD']` -> `['CI']`. Without this the release trigger goes dead silently.
- `README.md` -- build badge URL.

GitHub keys workflow history by file path, so the Actions sidebar will keep a stale `CI/CD` entry with the old runs and start fresh history for `ci.yml`.

## Verification

Locally, on this branch: `vp install --frozen-lockfile` (resolves to yarn 4.17.1), `vp run build` (tsc 7.0.2, `dist` emitted), `vp fmt --check`, `vp lint`, the full CI test command including the junit reporter, and `vp exec semantic-release --version` -> 25.0.8. `actionlint` and `pinact run --check` clean.

Not provable before merge: npm publishing now uses the npm bundled with the vp-managed Node instead of the one `actions/setup-node` shipped. Locally that pairing is Node 24.18.0 / npm 11.16.0, past the >=11.5.1 that semantic-release needs for OIDC trusted publishing.