### PR TITLE
fix(useStorageValue): type value by the resolved initializeWithValue

### DIFF
--- a/src/useLocalStorageValue/index.ts
+++ b/src/useLocalStorageValue/index.ts
@@ -1,4 +1,8 @@
-import type {UseStorageValueOptions, UseStorageValueResult} from '../useStorageValue/index.js';
+import type {
+	UseStorageValueDeferredOptions,
+	UseStorageValueOptions,
+	UseStorageValueResult,
+} from '../useStorageValue/index.js';
 import {useStorageValue} from '../useStorageValue/index.js';
 import {isBrowser, noop} from '../util/const.js';
 
@@ -10,20 +14,30 @@ try {
 	IS_LOCAL_STORAGE_AVAILABLE = false;
 }
 
-type UseLocalStorageValue = <
-	Type,
-	Default extends Type = Type,
-	Initialize extends boolean | undefined = boolean | undefined,
->(
-	key: string,
-	options?: UseStorageValueOptions<Type, Initialize>,
-) => UseStorageValueResult<Type, Default, Initialize>;
+type UseLocalStorageValue = {
+	<Type, Default extends Type = Type>(
+		key: string,
+		options: UseStorageValueDeferredOptions<Type>,
+	): UseStorageValueResult<Type, Default, false>;
+	<Type, Default extends Type = Type>(
+		key: string,
+		options?: UseStorageValueOptions<Type, true | undefined>,
+	): UseStorageValueResult<Type, Default, true>;
+	<Type, Default extends Type = Type, Initialize extends boolean | undefined = boolean | undefined>(
+		key: string,
+		options?: UseStorageValueOptions<Type, Initialize>,
+	): UseStorageValueResult<Type, Default, Initialize>;
+};
 
 /**
  * Manages a single localStorage key.
  */
 export const useLocalStorageValue: UseLocalStorageValue = IS_LOCAL_STORAGE_AVAILABLE
-	? (key, options) => useStorageValue(localStorage, key, options)
+	? <Type, Default extends Type = Type, Initialize extends boolean | undefined = boolean | undefined>(
+			key: string,
+			options?: UseStorageValueOptions<Type, Initialize>,
+		): UseStorageValueResult<Type, Default, Initialize> =>
+			useStorageValue<Type, Default, Initialize>(localStorage, key, options)
 	: <Type, Default extends Type = Type, Initialize extends boolean | undefined = boolean | undefined>(
 			_key: string,
 			_options?: UseStorageValueOptions<Type, Initialize>,

--- a/src/useLocalStorageValue/index.types.test.ts
+++ b/src/useLocalStorageValue/index.types.test.ts
@@ -1,0 +1,30 @@
+import {expectTypeOf} from 'vitest';
+import {useLocalStorageValue} from './index.js';
+
+declare const dynamicFlag: boolean;
+
+/**
+ * Type-level regression suite -- see `useStorageValue/index.types.test.ts` for
+ * the rationale. The wrapper declares its own overloads, so it needs its own
+ * assertions: a change to `useStorageValue` alone cannot keep it honest.
+ */
+export function useLocalStorageValueTypes(): void {
+	expectTypeOf(useLocalStorageValue<string>('key').value).toEqualTypeOf<string>();
+	expectTypeOf(useLocalStorageValue('key', {defaultValue: 'default'}).value).toEqualTypeOf<string>();
+	expectTypeOf(useLocalStorageValue<string>('key', {defaultValue: 'default'}).value).toEqualTypeOf<string>();
+	expectTypeOf(useLocalStorageValue<string>('key', {initializeWithValue: true}).value).toEqualTypeOf<string>();
+	expectTypeOf(useLocalStorageValue<string>('key', {initializeWithValue: undefined}).value).toEqualTypeOf<string>();
+
+	expectTypeOf(useLocalStorageValue<string>('key', {initializeWithValue: false}).value).toEqualTypeOf<
+		string | undefined
+	>();
+	expectTypeOf(useLocalStorageValue('key', {defaultValue: 'default', initializeWithValue: false}).value).toEqualTypeOf<
+		string | undefined
+	>();
+	expectTypeOf(useLocalStorageValue<string>('key', {initializeWithValue: dynamicFlag}).value).toEqualTypeOf<
+		string | undefined
+	>();
+
+	expectTypeOf(useLocalStorageValue<string, string, true>('key').value).toEqualTypeOf<string>();
+	expectTypeOf(useLocalStorageValue<string, string, false>('key').value).toEqualTypeOf<string | undefined>();
+}

--- a/src/useSessionStorageValue/index.ts
+++ b/src/useSessionStorageValue/index.ts
@@ -1,4 +1,8 @@
-import type {UseStorageValueOptions, UseStorageValueResult} from '../useStorageValue/index.js';
+import type {
+	UseStorageValueDeferredOptions,
+	UseStorageValueOptions,
+	UseStorageValueResult,
+} from '../useStorageValue/index.js';
 import {useStorageValue} from '../useStorageValue/index.js';
 import {isBrowser, noop} from '../util/const.js';
 
@@ -10,20 +14,30 @@ try {
 	IS_SESSION_STORAGE_AVAILABLE = false;
 }
 
-type UseSessionStorageValue = <
-	Type,
-	Default extends Type = Type,
-	Initialize extends boolean | undefined = boolean | undefined,
->(
-	key: string,
-	options?: UseStorageValueOptions<Type, Initialize>,
-) => UseStorageValueResult<Type, Default, Initialize>;
+type UseSessionStorageValue = {
+	<Type, Default extends Type = Type>(
+		key: string,
+		options: UseStorageValueDeferredOptions<Type>,
+	): UseStorageValueResult<Type, Default, false>;
+	<Type, Default extends Type = Type>(
+		key: string,
+		options?: UseStorageValueOptions<Type, true | undefined>,
+	): UseStorageValueResult<Type, Default, true>;
+	<Type, Default extends Type = Type, Initialize extends boolean | undefined = boolean | undefined>(
+		key: string,
+		options?: UseStorageValueOptions<Type, Initialize>,
+	): UseStorageValueResult<Type, Default, Initialize>;
+};
 
 /**
  * Manages a single sessionStorage key.
  */
 export const useSessionStorageValue: UseSessionStorageValue = IS_SESSION_STORAGE_AVAILABLE
-	? (key, options) => useStorageValue(sessionStorage, key, options)
+	? <Type, Default extends Type = Type, Initialize extends boolean | undefined = boolean | undefined>(
+			key: string,
+			options?: UseStorageValueOptions<Type, Initialize>,
+		): UseStorageValueResult<Type, Default, Initialize> =>
+			useStorageValue<Type, Default, Initialize>(sessionStorage, key, options)
 	: <Type, Default extends Type = Type, Initialize extends boolean | undefined = boolean | undefined>(
 			_key: string,
 			_options?: UseStorageValueOptions<Type, Initialize>,

--- a/src/useSessionStorageValue/index.types.test.ts
+++ b/src/useSessionStorageValue/index.types.test.ts
@@ -1,0 +1,30 @@
+import {expectTypeOf} from 'vitest';
+import {useSessionStorageValue} from './index.js';
+
+declare const dynamicFlag: boolean;
+
+/**
+ * Type-level regression suite -- see `useStorageValue/index.types.test.ts` for
+ * the rationale. The wrapper declares its own overloads, so it needs its own
+ * assertions: a change to `useStorageValue` alone cannot keep it honest.
+ */
+export function useSessionStorageValueTypes(): void {
+	expectTypeOf(useSessionStorageValue<string>('key').value).toEqualTypeOf<string>();
+	expectTypeOf(useSessionStorageValue('key', {defaultValue: 'default'}).value).toEqualTypeOf<string>();
+	expectTypeOf(useSessionStorageValue<string>('key', {defaultValue: 'default'}).value).toEqualTypeOf<string>();
+	expectTypeOf(useSessionStorageValue<string>('key', {initializeWithValue: true}).value).toEqualTypeOf<string>();
+	expectTypeOf(useSessionStorageValue<string>('key', {initializeWithValue: undefined}).value).toEqualTypeOf<string>();
+
+	expectTypeOf(useSessionStorageValue<string>('key', {initializeWithValue: false}).value).toEqualTypeOf<
+		string | undefined
+	>();
+	expectTypeOf(
+		useSessionStorageValue('key', {defaultValue: 'default', initializeWithValue: false}).value,
+	).toEqualTypeOf<string | undefined>();
+	expectTypeOf(useSessionStorageValue<string>('key', {initializeWithValue: dynamicFlag}).value).toEqualTypeOf<
+		string | undefined
+	>();
+
+	expectTypeOf(useSessionStorageValue<string, string, true>('key').value).toEqualTypeOf<string>();
+	expectTypeOf(useSessionStorageValue<string, string, false>('key').value).toEqualTypeOf<string | undefined>();
+}

--- a/src/useStorageValue/index.dom.test.ts
+++ b/src/useStorageValue/index.dom.test.ts
@@ -108,6 +108,29 @@ describe('useStorageValue', () => {
 		expect(expectResultValue(result.all[0]).value).toBe('bar');
 	});
 
+	it('should fetch value on first render in case `initializeWithValue` option is set to undefined', async () => {
+		const {result} = await renderHook(() =>
+			useStorageValue<string>(
+				newStorage(() => '"bar"'),
+				'foo',
+				{initializeWithValue: undefined},
+			),
+		);
+
+		expect(expectResultValue(result.all[0]).value).toBe('bar');
+	});
+
+	it('should yield null in case `defaultValue` option is set to undefined', async () => {
+		const {result} = await renderHook(() =>
+			// `exactOptionalPropertyTypes` rejects the explicit `undefined` here, but
+			// consumers without it -- and every JS consumer -- can still pass one.
+			// @ts-expect-error -- deliberately passing what the option type forbids
+			useStorageValue<string>(newStorage(), 'foo', {defaultValue: undefined}),
+		);
+
+		expect(expectResultValue(result).value).toBe(null);
+	});
+
 	it('should set storage value on .set() call', async () => {
 		const {result} = await renderHook(() => useStorageValue<string>(newStorage(), 'foo'));
 

--- a/src/useStorageValue/index.ts
+++ b/src/useStorageValue/index.ts
@@ -129,11 +129,6 @@ export type UseStorageValueResult<
 	fetch: () => void;
 };
 
-const DEFAULT_OPTIONS = {
-	defaultValue: null,
-	initializeWithValue: true,
-};
-
 export function useStorageValue<
 	Type,
 	Default extends Type = Type,
@@ -143,7 +138,13 @@ export function useStorageValue<
 	key: string,
 	options?: UseStorageValueOptions<Type, Initialize>,
 ): UseStorageValueResult<Type, Default, Initialize> {
-	const optionsRef = useSyncedRef({...DEFAULT_OPTIONS, ...options});
+	const optionsRef = useSyncedRef({
+		...options,
+		// An explicitly passed `undefined` must fall back to the documented
+		// default instead of overriding it, the way a spread over defaults would.
+		defaultValue: options?.defaultValue ?? null,
+		initializeWithValue: options?.initializeWithValue ?? true,
+	});
 	const parse = (str: string | null, fallback: Type | null): Type | null => {
 		const parseFunction = optionsRef.current.parse ?? defaultParse;
 		return parseFunction(str, fallback);

--- a/src/useStorageValue/index.ts
+++ b/src/useStorageValue/index.ts
@@ -109,6 +109,17 @@ export type UseStorageValueOptions<T, InitializeWithValue extends boolean | unde
 	stringify?: (data: T) => string | null;
 };
 
+/**
+ * Options of a hook that defers the first storage read until effects run.
+ *
+ * `initializeWithValue` is required so that an options object that omits it
+ * cannot match the deferred overload -- matching it would put `undefined` back
+ * into the result type of a hook that does read the value on the first render.
+ */
+export type UseStorageValueDeferredOptions<T> = UseStorageValueOptions<T, false> & {
+	initializeWithValue: false;
+};
+
 type UseStorageValueValue<
 	Type,
 	Default extends Type = Type,
@@ -129,6 +140,29 @@ export type UseStorageValueResult<
 	fetch: () => void;
 };
 
+export function useStorageValue<Type, Default extends Type = Type>(
+	storage: Storage,
+	key: string,
+	options: UseStorageValueDeferredOptions<Type>,
+): UseStorageValueResult<Type, Default, false>;
+export function useStorageValue<Type, Default extends Type = Type>(
+	storage: Storage,
+	key: string,
+	options?: UseStorageValueOptions<Type, true | undefined>,
+): UseStorageValueResult<Type, Default, true>;
+export function useStorageValue<
+	Type,
+	Default extends Type = Type,
+	Initialize extends boolean | undefined = boolean | undefined,
+>(
+	storage: Storage,
+	key: string,
+	options?: UseStorageValueOptions<Type, Initialize>,
+): UseStorageValueResult<Type, Default, Initialize>;
+
+/**
+ * Manages a single storage key.
+ */
 export function useStorageValue<
 	Type,
 	Default extends Type = Type,

--- a/src/useStorageValue/index.types.test.ts
+++ b/src/useStorageValue/index.types.test.ts
@@ -1,0 +1,80 @@
+import {expectTypeOf} from 'vitest';
+import type {NextState} from '../util/resolve-hook-state.js';
+import type {UseStorageValueResult} from './index.js';
+import {useStorageValue} from './index.js';
+
+declare const storage: Storage;
+declare const dynamicFlag: boolean;
+
+/**
+ * Type-level regression suite for the `value` field of the hook result.
+ *
+ * Nothing here runs -- the assertions are checked by the type-check pass of
+ * `vp lint`. `undefined` may only appear in `value` when `initializeWithValue`
+ * is not known to resolve to `true`, since deferring the first read until
+ * effects run is the only case that yields `undefined` to the caller.
+ *
+ * TypeScript does not infer a trailing type parameter when an earlier one is
+ * passed explicitly, so every case below is repeated with an explicit `Type` --
+ * that is the shape in which the bug originally surfaced.
+ */
+export function useStorageValueValueTypes(): void {
+	// `initializeWithValue` omitted -- the value is read during the first render.
+	expectTypeOf(useStorageValue<string>(storage, 'key').value).toEqualTypeOf<string>();
+	expectTypeOf(useStorageValue(storage, 'key', {defaultValue: 'default'}).value).toEqualTypeOf<string>();
+	expectTypeOf(useStorageValue<string>(storage, 'key', {defaultValue: 'default'}).value).toEqualTypeOf<string>();
+
+	// Explicit `true` behaves like the omitted case.
+	expectTypeOf(
+		useStorageValue(storage, 'key', {defaultValue: 'default', initializeWithValue: true}).value,
+	).toEqualTypeOf<string>();
+	expectTypeOf(useStorageValue<string>(storage, 'key', {initializeWithValue: true}).value).toEqualTypeOf<string>();
+
+	// An explicit `undefined` falls back to the default, so the value is read too.
+	expectTypeOf(useStorageValue<string>(storage, 'key', {initializeWithValue: undefined}).value).toEqualTypeOf<string>();
+
+	// Explicit `false` defers the read, so the first render yields `undefined`.
+	expectTypeOf(useStorageValue(storage, 'key', {defaultValue: 'default', initializeWithValue: false}).value)
+		//
+		.toEqualTypeOf<string | undefined>();
+	expectTypeOf(useStorageValue<string>(storage, 'key', {initializeWithValue: false}).value).toEqualTypeOf<
+		string | undefined
+	>();
+
+	// A flag unknown at compile time may turn out to be `false`.
+	expectTypeOf(useStorageValue(storage, 'key', {defaultValue: 'default', initializeWithValue: dynamicFlag}).value)
+		//
+		.toEqualTypeOf<string | undefined>();
+	expectTypeOf(useStorageValue<string>(storage, 'key', {initializeWithValue: dynamicFlag}).value).toEqualTypeOf<
+		string | undefined
+	>();
+
+	// Explicit type arguments keep addressing the same overload they used to.
+	expectTypeOf(useStorageValue<string, string, true>(storage, 'key').value).toEqualTypeOf<string>();
+	expectTypeOf(useStorageValue<string, string, false>(storage, 'key').value).toEqualTypeOf<string | undefined>();
+}
+
+/**
+ * `set` receives the value type the hook yields, so an updater callback must not
+ * be handed an `undefined` previous state unless the read is deferred.
+ */
+export function useStorageValueSetTypes(): void {
+	expectTypeOf(useStorageValue<string>(storage, 'key').set).parameter(0).toEqualTypeOf<NextState<string, string>>();
+
+	expectTypeOf(useStorageValue<string>(storage, 'key', {initializeWithValue: false}).set)
+		.parameter(0)
+		.toEqualTypeOf<NextState<string, string | undefined>>();
+}
+
+/**
+ * The exported result type keeps its three parameters, and instantiating it by
+ * hand -- the way a consumer annotates a variable -- resolves the same way.
+ */
+export function useStorageValueResultTypes(): void {
+	expectTypeOf<UseStorageValueResult<string, string, true>['value']>().toEqualTypeOf<string>();
+	expectTypeOf<UseStorageValueResult<string, string, false>['value']>().toEqualTypeOf<string | undefined>();
+	expectTypeOf<UseStorageValueResult<string, string, boolean>['value']>().toEqualTypeOf<string | undefined>();
+
+	// Without a known `initializeWithValue`, the type stays conservative.
+	expectTypeOf<UseStorageValueResult<string>['value']>().toEqualTypeOf<string | undefined>();
+}


### PR DESCRIPTION
`value` carried a bogus `undefined` whenever `initializeWithValue` was left at its default, forcing null checks that
can never fire. The runtime has read storage on the first render since `17.0.1` (#1002); the type never followed.

Supersedes #1647, which reported the same defect and targets the same conditional.

### Problem

```ts
const {value} = useSessionStorageValue('name', {defaultValue: 'anonymous'});
//     ^? string | undefined
const token = useLocalStorageValue<string>('token').value;
//     ^? string | undefined
```

`Initialize` is only inferable from a literal `initializeWithValue` in the options object. Anything else leaves it at
the type-parameter default `boolean | undefined`, and since it is the checked type of a conditional, it distributes:

```ts
U = Initialize extends false ? undefined | N : N
// true      extends false -> N
// false     extends false -> undefined | N   <- contributes the undefined
// undefined extends false -> N
```

Flipping the conditional to `false extends Initialize`, as #1647 does, yields the same union — `false` is assignable to
`boolean | undefined`, so the deferred branch is picked anyway. The two forms are in fact interchangeable for every
instantiation the hooks can produce; asserting mutual assignability across `true`, `false`, `undefined`, `boolean` and
`boolean | undefined` compiles clean, and they diverge only on `never`.

So the defect is in the signature, not in the conditional.

Nor is raising the default to `true` enough. TypeScript does not infer a trailing type parameter once an earlier one is
passed explicitly — omitted ones take their defaults — so `Initialize` is never inferred when `Type` is written out, and
the documented SSR form stops compiling:

```ts
useLocalStorageValue<string>('key', {initializeWithValue: false});
//                                   ^ Type 'false' is not assignable to type 'true'.
```

### Change

Two overloads pick the result type, with the existing three-parameter signature kept as a third:

```ts
export function useStorageValue<Type, Default extends Type = Type>(
	storage: Storage, key: string, options: UseStorageValueDeferredOptions<Type>,
): UseStorageValueResult<Type, Default, false>;
export function useStorageValue<Type, Default extends Type = Type>(
	storage: Storage, key: string, options?: UseStorageValueOptions<Type, true | undefined>,
): UseStorageValueResult<Type, Default, true>;
```

`UseStorageValueDeferredOptions` is `UseStorageValueOptions<T, false>` with `initializeWithValue` **required**, so
`{defaultValue: 'x'}` cannot match the deferred overload and fall through it. `Default` is inert either way — it is
unreachable by inference — but it stays, along with the third overload, so `useLocalStorageValue<string, string, false>`
resolves exactly as before.

`UseStorageValueValue` is untouched. Given a literal `Initialize`, the original conditional is already right.

Both wrappers declare their own signatures, so both get the same overload set.

One runtime fix is required to make the second overload honest. Options were resolved as
`{...DEFAULT_OPTIONS, ...options}`, and a spread copies an own key even when its value is `undefined` — so
`{initializeWithValue: undefined}` overrode the `true` default and deferred the read, while `{defaultValue: undefined}`
replaced the `null` fallback handed to `parse`. Both now resolve with `??`, the pattern `useCookieValue` and
`useScreenOrientation` already use.

### Resulting types

Measured by assigning each call's `value` to `string` in a scratch consumer, against published `26.1.0` and against the
packed branch build.

| Call                                                                  | Before                | After                 |
| --------------------------------------------------------------------- | --------------------- | --------------------- |
| `useLocalStorageValue<string>('k')`                                   | `string \| undefined` | `string`              |
| `useLocalStorageValue('k', {defaultValue: 'x'})`                      | `string \| undefined` | `string`              |
| `useLocalStorageValue<string>('k', {initializeWithValue: true})`       | `string \| undefined` | `string`              |
| `useLocalStorageValue<string>('k', {initializeWithValue: undefined})`  | `string \| undefined` | `string`              |
| `useLocalStorageValue<string>('k', {initializeWithValue: false})`      | `string \| undefined` | `string \| undefined` |
| `useLocalStorageValue<string>('k', {initializeWithValue: flag})`       | `string \| undefined` | `string \| undefined` |
| `useLocalStorageValue<string, string, true>('k')`                      | `string`              | `string`              |
| `useLocalStorageValue<string, string, false>('k')`                     | `string \| undefined` | `string \| undefined` |

Narrowing only, and never in the other direction. Every call that compiled before still compiles, so this is a patch,
not a break.

### Tests

Type-level assertions in `index.types.test.ts` beside each of the three hooks — every overload, every
`initializeWithValue` form, a runtime `boolean` flag, `set`'s previous-state parameter, and the explicit type-argument
calls. Each case is repeated with an explicit `Type`, which is the shape the defect hid in.

The name matches neither vitest project pattern, so nothing runs; `vp lint`'s `typeCheck` pass is the gate. Verified by
breaking an assertion:

```
src/useLocalStorageValue/index.types.test.ts:12:72: error typescript(TS2344):
  Type 'string | undefined' does not satisfy the constraint
  '"Expected: string, Actual: never" | "Expected: undefined, Actual: never"'.
```

Two DOM tests cover the option resolution: `initializeWithValue: undefined` reads on the first render,
`defaultValue: undefined` yields `null`. The second needs `@ts-expect-error` — `exactOptionalPropertyTypes` rejects the
explicit `undefined`, but consumers without it, and every JS consumer, can still pass one.

### Verification

`vp fmt --check`, `vp lint`, `vp test --run` and `vp run build` pass on both commits. Coverage on the wrappers is
unchanged at 75%; branch coverage on `useStorageValue` goes 91.52% -> 92.06%.

Packed the tarball and typechecked a scratch consumer against it (`react@19`, `moduleResolution: NodeNext`): the
reproduction above exits 0, and the legacy three-type-argument calls, the `UseStorageValueResult` hand annotation, the
barrel import and the `@react-hookz/web/useStorageValue` subpath all still resolve.

### Scope

The result type still claims `Type` when no `defaultValue` is given, though a missing key yields `null` at runtime.
`Default` is unreachable by inference (`defaultValue?: T`, not `?: Default`), so the `null | Type` branch of
`UseStorageValueValue` is dead. Fixing that means `value: string | null` for `useLocalStorageValue<string>('key')` — a
break that needs its own major. Left alone here.

## Checklist

- [x] Have you read [contribution guideline](../../CONTRIBUTING.md)?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - Closes #1697
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
  - n/a — the JSDoc on `initializeWithValue` already documents `@default true`; this makes the type agree with it
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?
